### PR TITLE
Added %file_name_without_any_extensions% placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,11 @@ Crowdin CLI allows to use the following placeholders to put appropriate variable
     </tr>
     <tr>
       <td>%file_name%</td>
-      <td>File name without extension</td>
+      <td>File name without the last extension</td>
+    </tr>
+    <tr>
+      <td>%file_name_without_any_extensions%</td>
+      <td>File name without any extensions</td>
     </tr>
   </tbody>
 </table>

--- a/src/main/java/com/crowdin/cli/BaseCli.java
+++ b/src/main/java/com/crowdin/cli/BaseCli.java
@@ -60,6 +60,8 @@ public class BaseCli {
 
     protected static final String PLACEHOLDER_FILE_NAME = "%file_name%";
 
+    protected static final String PLACEHOLDER_FILE_NAME_WITHOUT_ANY_EXT = "%file_name_without_any_extensions%";
+
     protected static final String PLACEHOLDER_LANGUAGE = "%language%";
 
     protected static final String PLACEHOLDER_LOCALE = "%locale%";

--- a/src/main/java/com/crowdin/cli/utils/CommandUtils.java
+++ b/src/main/java/com/crowdin/cli/utils/CommandUtils.java
@@ -818,6 +818,7 @@ public class CommandUtils extends BaseCli {
                             String temporaryTranslation = translations;
                             String originalFileName = f.getName();
                             String fileNameWithoutExt = FilenameUtils.removeExtension(f.getName());
+                            String fileNameWithoutAnyExt = f.getName().replaceFirst("[.].+$", "");
                             String fileExt = FilenameUtils.getExtension(f.getName());
                             String fileParent = new File(f.getParent()).getAbsolutePath();
                             if (!propertiesBean.getPreserveHierarchy() && "download".equals(command)) {
@@ -839,6 +840,7 @@ public class CommandUtils extends BaseCli {
                             String osxCode = Utils.getOsXLocaleCode(langsInfo.getString("crowdin_code"));
                             temporaryTranslation = temporaryTranslation.replace(PLACEHOLDER_ORIGINAL_FILE_NAME, originalFileName);
                             temporaryTranslation = temporaryTranslation.replace(PLACEHOLDER_FILE_NAME, fileNameWithoutExt);
+                            temporaryTranslation = temporaryTranslation.replace(PLACEHOLDER_FILE_NAME_WITHOUT_ANY_EXT, fileNameWithoutAnyExt);
                             temporaryTranslation = temporaryTranslation.replace(PLACEHOLDER_FILE_EXTENTION, fileExt);
                             temporaryTranslation = temporaryTranslation.replace(PLACEHOLDER_ORIGINAL_PATH, fileParent);
                             temporaryTranslation = temporaryTranslation.replace(PLACEHOLDER_ANDROID_CODE, androidLocaleCode);


### PR DESCRIPTION
Hi there,

Our project files are named 'source.en.yml', so we needed to strip more than the last extension.
Here's a pull request to add the placeholder `%file_name_without_any_extensions%` to facilitate this.

Thanks,

Christian