### PR TITLE
Allow symlinks as source files

### DIFF
--- a/src/main/java/com/crowdin/cli/utils/CommandUtils.java
+++ b/src/main/java/com/crowdin/cli/utils/CommandUtils.java
@@ -141,7 +141,7 @@ public class CommandUtils extends BaseCli {
         List<String> result = new ArrayList<>();
         if (sourcesWithoutIgnores != null) {
             for (File source : sourcesWithoutIgnores) {
-                if (source.isFile()) {
+                if (source.isFile() || Files.isSymbolicLink(source.toPath())) {
                     result.add(source.getAbsolutePath());
                 }
             }


### PR DESCRIPTION
Hi!
I ran into an issue today while upgrading from `crowdin-cli` to `crowdin-cli-2` where our symlinked translation source files were not properly processed. The patch in this pull request works fine for our symlinked files also.
Thanks,
Manfred 