### PR TITLE
Install shell script: don't use sudo

### DIFF
--- a/scripts/install-crowdin-cli.sh
+++ b/scripts/install-crowdin-cli.sh
@@ -1,3 +1,5 @@
+if [[ $(id -u) -ne 0 ]] ; then echo "Please run as root" ; exit 1 ; fi
+
 echo "Checking JAVA installation..."
 copySuccessed=1
 
@@ -19,18 +21,18 @@ if [[ "$_java" ]]; then
 
         echo "Installing Crowdin CLI..."
 
-        sudo cp crowdin-cli.jar /usr/local/bin
+        cp crowdin-cli.jar /usr/local/bin
 
         copySuccessed=$?
 
-        [ -d "/etc/bash_completion.d" ] && sudo cp crowdin_completion /etc/bash_completion.d/crowdin_completion
-        [ -d "/usr/local/etc/bash_completion.d" ] && sudo cp crowdin_completion /usr/local/etc/bash_completion.d/crowdin_completion
+        [ -d "/etc/bash_completion.d" ] && cp crowdin_completion /etc/bash_completion.d/crowdin_completion
+        [ -d "/usr/local/etc/bash_completion.d" ] && cp crowdin_completion /usr/local/etc/bash_completion.d/crowdin_completion
 
-        sudo sh -c "cat > /usr/local/bin/crowdin << EOF
+        sh -c "cat > /usr/local/bin/crowdin << EOF
 #!/bin/sh
 exec /usr/bin/java -jar '/usr/local/bin/crowdin-cli.jar' \"\\\$@\"
 EOF"
-        sudo chmod +x /usr/local/bin/crowdin
+        chmod +x /usr/local/bin/crowdin
 
     else
         echo Your Java version is "$version" - needs to be updated. You can download it from https://www.java.com/


### PR DESCRIPTION
I have a suggestion to remove `sudo` from the installation script.

First of all, I think that the general convention about install scripts is that the user is expected to run the script with the root permissions e.g. (`sudo make install`) and it was my assumption when I first saw the script.

Also on your web page about cli [here](https://support.crowdin.com/cli-tool/) you say:
> Run ./install-crowdin-cli.sh in the terminal with sudo rights in order to add crowdin command to your terminal

It's not 100% clear what is meant here but my first interpretation would be that I have to run the script as root like `sudo ./install-crowdin-cli.sh` which makes the `sudo` call unnecessary. 

And another point against building in `sudo` is that in general a UNIX-like OS doesn't have to include `sudo`. It looks like most of the popular OSs include `sudo` by default, like Ubuntu and macOS, but in general an arbitrary GNU/Linux distribution may miss it. For instance on Arch Linux it's not bundled in the base system and installed optionally. In this case the user would have to modify the installation script to use it. So while it's safe to assume that most of the cli users would have `sudo` but it would be more compatible to let the user decide how to get the root permissions. For some setups it you might have to use `su` command for that.

I added a user ID check in the beginning so if the user accidentally calls it as a usual user the script would tell the user to run it as root.

I understand that you may have some different reasoning behind designing the installation script in a specific way. In this case I'd be happy to discuss.