### PR TITLE
crowdin-cli: Introduce a plain mode for usage in scripts

### DIFF
--- a/src/main/java/com/crowdin/cli/Cli.java
+++ b/src/main/java/com/crowdin/cli/Cli.java
@@ -7,6 +7,7 @@ import picocli.CommandLine;
 
 import java.net.Authenticator;
 import java.net.PasswordAuthentication;
+import java.util.Arrays;
 
 import static com.crowdin.cli.utils.console.ExecutionStatus.ERROR;
 
@@ -24,7 +25,10 @@ public class Cli {
             HelpCommand.setOptions(commandLine, System.out, colorScheme);
             int exitCode = commandLine.execute(args);
 
-            Utils.getNewVersionMassage().ifPresent(System.out::println);
+            boolean plain = Arrays.stream(args).anyMatch("--plain"::equals);
+            if(!plain) {
+                Utils.getNewVersionMassage().ifPresent(System.out::println);
+            }
 
             System.exit(exitCode);
         } catch (Exception e) {

--- a/src/main/java/com/crowdin/cli/commands/actions/ListProjectAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/ListProjectAction.java
@@ -17,18 +17,22 @@ public class ListProjectAction implements Action {
     private boolean noProgress;
     private String branchName;
     private boolean treeView;
+    private boolean plainView;
 
-    public ListProjectAction(boolean noProgress, String branchName, boolean treeView) {
-        this.noProgress = noProgress;
+    public ListProjectAction(boolean noProgress, String branchName, boolean treeView, boolean plainView) {
+        this.noProgress = noProgress || plainView;
         this.branchName = branchName;
         this.treeView = treeView;
+        this.plainView = plainView;
     }
 
     @Override
     public void act(PropertiesBean pb, Client client) {
         Project project;
         try {
-            ConsoleSpinner.start(RESOURCE_BUNDLE.getString("message.spinner.fetching_project_info"), this.noProgress);
+            if (!plainView) {
+                ConsoleSpinner.start(RESOURCE_BUNDLE.getString("message.spinner.fetching_project_info"), this.noProgress);
+            }
             project = client.downloadFullProject();
             ConsoleSpinner.stop(OK);
         } catch (Exception e) {
@@ -42,6 +46,6 @@ public class ListProjectAction implements Action {
                 .orElseThrow(() -> new RuntimeException(RESOURCE_BUNDLE.getString("error.not_found_branch")))
             : null;
 
-        (new DryrunProjectFiles(project.getFiles(), project.getDirectories(), project.getBranches(), branchId)).run(treeView);
+        (new DryrunProjectFiles(project.getFiles(), project.getDirectories(), project.getBranches(), branchId)).run(treeView, plainView);
     }
 }

--- a/src/main/java/com/crowdin/cli/commands/actions/ListSourcesAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/ListSourcesAction.java
@@ -15,17 +15,21 @@ public class ListSourcesAction implements Action {
 
     private boolean noProgress;
     private boolean treeView;
+    private boolean plainView;
 
-    public ListSourcesAction(boolean noProgress, boolean treeView) {
-        this.noProgress = noProgress;
+    public ListSourcesAction(boolean noProgress, boolean treeView, boolean plainView) {
+        this.noProgress = noProgress || plainView;
         this.treeView = treeView;
+        this.plainView = plainView;
     }
 
     @Override
     public void act(PropertiesBean pb, Client client) {
         Project project;
         try {
-            ConsoleSpinner.start(RESOURCE_BUNDLE.getString("message.spinner.fetching_project_info"), this.noProgress);
+            if (!plainView) {
+                ConsoleSpinner.start(RESOURCE_BUNDLE.getString("message.spinner.fetching_project_info"), this.noProgress);
+            }
             project = client.downloadProjectWithLanguages();
             ConsoleSpinner.stop(OK);
         } catch (Exception e) {
@@ -34,6 +38,6 @@ public class ListSourcesAction implements Action {
         }
         PlaceholderUtil placeholderUtil = new PlaceholderUtil(project.getSupportedLanguages(), project.getProjectLanguages(false), pb.getBasePath());
 
-        (new DryrunSources(pb, placeholderUtil)).run(treeView);
+        (new DryrunSources(pb, placeholderUtil)).run(treeView, plainView);
     }
 }

--- a/src/main/java/com/crowdin/cli/commands/actions/ListTranslationsAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/ListTranslationsAction.java
@@ -17,18 +17,22 @@ public class ListTranslationsAction implements Action {
     private boolean noProgress;
     private boolean treeView;
     private boolean isLocal;
+    private boolean plainView;
 
-    public ListTranslationsAction(boolean noProgress, boolean treeView, boolean isLocal) {
+    public ListTranslationsAction(boolean noProgress, boolean treeView, boolean isLocal, boolean plainView) {
         this.noProgress = noProgress;
         this.treeView = treeView;
         this.isLocal = isLocal;
+        this.plainView = plainView;
     }
 
     @Override
     public void act(PropertiesBean pb, Client client) {
         Project project;
         try {
-            ConsoleSpinner.start(RESOURCE_BUNDLE.getString("message.spinner.fetching_project_info"), this.noProgress);
+            if (!plainView) {
+                ConsoleSpinner.start(RESOURCE_BUNDLE.getString("message.spinner.fetching_project_info"), this.noProgress);
+            }
             project = client.downloadProjectWithLanguages();
             ConsoleSpinner.stop(OK);
         } catch (Exception e) {
@@ -43,6 +47,6 @@ public class ListTranslationsAction implements Action {
 
         PlaceholderUtil placeholderUtil = new PlaceholderUtil(project.getSupportedLanguages(), project.getProjectLanguages(!isLocal), pb.getBasePath());
 
-        (new DryrunTranslations(pb, project.getLanguageMapping(), placeholderUtil, Optional.empty(), false)).run(treeView);
+        (new DryrunTranslations(pb, project.getLanguageMapping(), placeholderUtil, Optional.empty(), false)).run(treeView, plainView);
     }
 }

--- a/src/main/java/com/crowdin/cli/commands/actions/UploadTranslationsAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/UploadTranslationsAction.java
@@ -34,21 +34,25 @@ public class UploadTranslationsAction implements Action {
     private boolean importEqSuggestions;
     private boolean autoApproveImported;
     private boolean debug;
+    private boolean plainView;
 
-    public UploadTranslationsAction(boolean noProgress, String languageId, String branchName, boolean importEqSuggestions, boolean autoApproveImported, boolean debug) {
-        this.noProgress = noProgress;
+    public UploadTranslationsAction(boolean noProgress, String languageId, String branchName, boolean importEqSuggestions, boolean autoApproveImported, boolean debug, boolean plainView) {
+        this.noProgress = noProgress || plainView;
         this.languageId = languageId;
         this.branchName = branchName;
         this.importEqSuggestions = importEqSuggestions;
         this.autoApproveImported = autoApproveImported;
         this.debug = debug;
+        this.plainView = plainView;
     }
 
     @Override
     public void act(PropertiesBean pb, Client client) {
         Project project;
         try {
-            ConsoleSpinner.start(RESOURCE_BUNDLE.getString("message.spinner.fetching_project_info"), this.noProgress);
+            if (!plainView) {
+                ConsoleSpinner.start(RESOURCE_BUNDLE.getString("message.spinner.fetching_project_info"), this.noProgress);
+            }
             project = client.downloadFullProject();
             ConsoleSpinner.stop(OK);
         } catch (Exception e) {
@@ -84,7 +88,9 @@ public class UploadTranslationsAction implements Action {
                 : SourcesUtils.getCommonPath(fileSourcesWithoutIgnores, pb.getBasePath());
 
             if (fileSourcesWithoutIgnores.isEmpty()) {
-                System.out.println(ERROR.withIcon(RESOURCE_BUNDLE.getString("error.no_sources")));
+                if (!plainView) {
+                    System.out.println(ERROR.withIcon(RESOURCE_BUNDLE.getString("error.no_sources")));
+                }
                 continue;
             }
 
@@ -96,7 +102,9 @@ public class UploadTranslationsAction implements Action {
                     : StringUtils.removeStart(source, pb.getBasePath() + commonPath));
 
                 if (!paths.containsKey(filePath)) {
-                    System.out.println(ERROR.withIcon(String.format(RESOURCE_BUNDLE.getString("error.source_not_exists_in_project"), StringUtils.removeStart(source, pb.getBasePath()), filePath)));
+                    if (!plainView) {
+                        System.out.println(ERROR.withIcon(String.format(RESOURCE_BUNDLE.getString("error.source_not_exists_in_project"), StringUtils.removeStart(source, pb.getBasePath()), filePath)));
+                    }
                     return;
                 }
                 Long fileId = paths.get(filePath).getId();
@@ -108,7 +116,9 @@ public class UploadTranslationsAction implements Action {
                 if (file.getScheme() != null) {
                     java.io.File transFile = new java.io.File(pb.getBasePath() + Utils.PATH_SEPARATOR + translation);
                     if (!transFile.exists()) {
-                        System.out.println(SKIPPED.withIcon(String.format(RESOURCE_BUNDLE.getString("error.translation_not_exists"), StringUtils.removeStart(transFile.getAbsolutePath(), pb.getBasePath()))));
+                        if (!plainView) {
+                            System.out.println(SKIPPED.withIcon(String.format(RESOURCE_BUNDLE.getString("error.translation_not_exists"), StringUtils.removeStart(transFile.getAbsolutePath(), pb.getBasePath()))));
+                        }
                         return;
                     }
                     UploadTranslationsRequest request = new UploadTranslationsRequest();
@@ -127,7 +137,9 @@ public class UploadTranslationsAction implements Action {
                         transFileName = PropertiesBeanUtils.useTranslationReplace(transFileName, file.getTranslationReplace());
                         java.io.File transFile = new java.io.File(pb.getBasePath() + Utils.PATH_SEPARATOR + transFileName);
                         if (!transFile.exists()) {
-                            System.out.println(SKIPPED.withIcon(String.format(RESOURCE_BUNDLE.getString("error.translation_not_exists"), StringUtils.removeStart(transFile.getAbsolutePath(), pb.getBasePath()))));
+                            if (!plainView) {
+                                System.out.println(SKIPPED.withIcon(String.format(RESOURCE_BUNDLE.getString("error.translation_not_exists"), StringUtils.removeStart(transFile.getAbsolutePath(), pb.getBasePath()))));
+                            }
                             continue;
                         }
                         UploadTranslationsRequest request = new UploadTranslationsRequest();
@@ -158,8 +170,12 @@ public class UploadTranslationsAction implements Action {
                     } catch (Exception e) {
                         throw new RuntimeException(RESOURCE_BUNDLE.getString("error.upload_translation"), e);
                     }
-                    System.out.println(
-                            OK.withIcon(String.format(RESOURCE_BUNDLE.getString("message.translation_uploaded"), StringUtils.removeStart(translationFile.getAbsolutePath(), pb.getBasePath()))));
+                    if (!plainView) {
+                        System.out.println(
+                                OK.withIcon(String.format(RESOURCE_BUNDLE.getString("message.translation_uploaded"), StringUtils.removeStart(translationFile.getAbsolutePath(), pb.getBasePath()))));
+                    } else {
+                        System.out.println(StringUtils.removeStart(translationFile.getAbsolutePath(), pb.getBasePath()));
+                    }
                 })
                 .collect(Collectors.toList());
             ConcurrencyUtil.executeAndWait(tasks, debug);

--- a/src/main/java/com/crowdin/cli/commands/actions/UploadTranslationsAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/UploadTranslationsAction.java
@@ -84,7 +84,8 @@ public class UploadTranslationsAction implements Action {
                 : SourcesUtils.getCommonPath(fileSourcesWithoutIgnores, pb.getBasePath());
 
             if (fileSourcesWithoutIgnores.isEmpty()) {
-                throw new RuntimeException(RESOURCE_BUNDLE.getString("error.no_sources"));
+                System.out.println(ERROR.withIcon(RESOURCE_BUNDLE.getString("error.no_sources")));
+                continue;
             }
 
             Map<java.io.File, Pair<List<Language>, UploadTranslationsRequest>> preparedRequests = new HashMap<>();

--- a/src/main/java/com/crowdin/cli/commands/functionality/Dryrun.java
+++ b/src/main/java/com/crowdin/cli/commands/functionality/Dryrun.java
@@ -24,6 +24,10 @@ public abstract class Dryrun {
     }
 
     public void run(boolean treeView) {
+        run(treeView, false);
+    }
+
+    public void run(boolean treeView, boolean plainView) {
         List<String> files = getFiles()
             .stream()
             .map(f -> f.replaceAll("^[/\\\\]+", ""))
@@ -32,7 +36,11 @@ public abstract class Dryrun {
         if (treeView) {
             DrawTree.draw(files).forEach(System.out::println);
         } else {
-            files.forEach(file -> System.out.println(OK.withIcon(String.format(RESOURCE_BUNDLE.getString(message_key), file))));
+            if (!plainView) {
+                files.forEach(file -> System.out.println(OK.withIcon(String.format(RESOURCE_BUNDLE.getString(message_key), file))));
+            } else {
+                files.forEach(file -> System.out.println(file));
+            }
         }
     }
 }

--- a/src/main/java/com/crowdin/cli/commands/picocli/DownloadSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/DownloadSubcommand.java
@@ -40,6 +40,8 @@ public class DownloadSubcommand extends Command {
     @CommandLine.Option(names = {"--export-only-approved"}, descriptionKey = "crowdin.download.exportOnlyApproved")
     protected Boolean exportApprovedOnly;
 
+    @CommandLine.Option(names = {"--plain"}, descriptionKey = "crowdin.list.usage.plain")
+    protected boolean plainView;
 
     @CommandLine.Mixin
     private PropertiesBuilderCommandPart propertiesBuilderCommandPart;
@@ -52,8 +54,8 @@ public class DownloadSubcommand extends Command {
         FilesInterface files = new FSFiles();
 
         Action action = (dryrun)
-            ? new ListTranslationsAction(noProgress, treeView, false)
-            : new DownloadAction(files, noProgress, languageId, branchName, ignoreMatch, isVerbose, skipTranslatedOnly, skipUntranslatedFiles, exportApprovedOnly);
+            ? new ListTranslationsAction(noProgress, treeView, false, plainView)
+            : new DownloadAction(files, noProgress, languageId, branchName, ignoreMatch, isVerbose, skipTranslatedOnly, skipUntranslatedFiles, exportApprovedOnly, plainView);
         action.act(pb, client);
     }
 }

--- a/src/main/java/com/crowdin/cli/commands/picocli/ListProjectSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/ListProjectSubcommand.java
@@ -18,6 +18,9 @@ public class ListProjectSubcommand extends Command {
     @CommandLine.Option(names = {"--tree"})
     protected boolean treeView;
 
+    @CommandLine.Option(names = {"--plain"}, descriptionKey = "crowdin.list.usage.plain")
+    protected boolean plainView;
+
     @CommandLine.Mixin
     private PropertiesBuilderCommandPart propertiesBuilderCommandPart;
 
@@ -26,7 +29,7 @@ public class ListProjectSubcommand extends Command {
         PropertiesBean pb = propertiesBuilderCommandPart.buildPropertiesBean();
         Client client = new CrowdinClient(pb.getApiToken(), pb.getBaseUrl(), Long.parseLong(pb.getProjectId()));
 
-        Action action = new ListProjectAction(noProgress, branch, treeView);
+        Action action = new ListProjectAction(noProgress, branch, treeView, plainView);
         action.act(pb, client);
     }
 }

--- a/src/main/java/com/crowdin/cli/commands/picocli/ListSourcesSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/ListSourcesSubcommand.java
@@ -18,6 +18,9 @@ public class ListSourcesSubcommand extends Command {
     @CommandLine.Option(names = {"--tree"})
     protected boolean treeView;
 
+    @CommandLine.Option(names = {"--plain"}, descriptionKey = "crowdin.list.usage.plain")
+    protected boolean plainView;
+
     @CommandLine.Mixin
     private PropertiesBuilderCommandPart propertiesBuilderCommandPart;
 
@@ -26,7 +29,7 @@ public class ListSourcesSubcommand extends Command {
         PropertiesBean pb = propertiesBuilderCommandPart.buildPropertiesBean();
         Client client = new CrowdinClient(pb.getApiToken(), pb.getBaseUrl(), Long.parseLong(pb.getProjectId()));
 
-        Action action = new ListSourcesAction(this.noProgress, this.treeView);
+        Action action = new ListSourcesAction(this.noProgress, this.treeView, this.plainView);
         action.act(pb, client);
     }
 }

--- a/src/main/java/com/crowdin/cli/commands/picocli/ListTranslationsSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/ListTranslationsSubcommand.java
@@ -15,6 +15,9 @@ public class ListTranslationsSubcommand extends Command {
     @CommandLine.Option(names = {"--tree"})
     protected boolean treeView;
 
+    @CommandLine.Option(names = {"--plain"}, descriptionKey = "crowdin.list.usage.plain")
+    protected boolean plainView;
+
     @CommandLine.Mixin
     private PropertiesBuilderCommandPart propertiesBuilderCommandPart;
 
@@ -23,7 +26,7 @@ public class ListTranslationsSubcommand extends Command {
         PropertiesBean pb = propertiesBuilderCommandPart.buildPropertiesBean();
         Client client = new CrowdinClient(pb.getApiToken(), pb.getBaseUrl(), Long.parseLong(pb.getProjectId()));
 
-        Action action = new ListTranslationsAction(noProgress, treeView, false);
+        Action action = new ListTranslationsAction(noProgress, treeView, false, plainView);
         action.act(pb, client);
     }
 }

--- a/src/main/java/com/crowdin/cli/commands/picocli/UploadSourcesCommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/UploadSourcesCommand.java
@@ -23,6 +23,9 @@ public class UploadSourcesCommand extends Command {
     @CommandLine.Option(names = {"--tree"}, descriptionKey = "tree.dryrun")
     protected boolean treeView;
 
+    @CommandLine.Option(names = {"--plain"}, descriptionKey = "crowdin.list.usage.plain")
+    protected boolean plainView;
+
     @CommandLine.Mixin
     private PropertiesBuilderCommandPart propertiesBuilderCommandPart;
 
@@ -32,8 +35,8 @@ public class UploadSourcesCommand extends Command {
         Client client = new CrowdinClient(pb.getApiToken(), pb.getBaseUrl(), Long.parseLong(pb.getProjectId()));
 
         Action action = (dryrun)
-            ? new ListSourcesAction(this.noProgress, this.treeView)
-            : new UploadSourcesAction(this.branch, this.noProgress, this.autoUpdate, debug);
+            ? new ListSourcesAction(this.noProgress, this.treeView, plainView)
+            : new UploadSourcesAction(this.branch, this.noProgress, this.autoUpdate, debug, plainView);
         action.act(pb, client);
     }
 }

--- a/src/main/java/com/crowdin/cli/commands/picocli/UploadTranslationsSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/UploadTranslationsSubcommand.java
@@ -33,6 +33,9 @@ public class UploadTranslationsSubcommand extends Command {
     @CommandLine.Option(names = {"--tree"}, descriptionKey = "tree.dryrun")
     protected boolean treeView;
 
+    @CommandLine.Option(names = {"--plain"}, descriptionKey = "crowdin.list.usage.plain")
+    protected boolean plainView;
+
     @CommandLine.Mixin
     private PropertiesBuilderCommandPart propertiesBuilderCommandPart;
 
@@ -42,8 +45,8 @@ public class UploadTranslationsSubcommand extends Command {
         Client client = new CrowdinClient(pb.getApiToken(), pb.getBaseUrl(), Long.parseLong(pb.getProjectId()));
 
         Action action = (dryrun)
-            ? new ListTranslationsAction(noProgress, treeView, true)
-            : new UploadTranslationsAction(noProgress, languageId, branch, importEqSuggestions, autoApproveImported, debug);
+            ? new ListTranslationsAction(noProgress, treeView, true, plainView)
+            : new UploadTranslationsAction(noProgress, languageId, branch, importEqSuggestions, autoApproveImported, debug, plainView);
         action.act(pb, client);
     }
 }

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -46,6 +46,9 @@ crowdin.generate.destination=Place where the configuration skeleton should be sa
 crowdin.lint.usage.description=Analyze your configuration file for potential errors
 crowdin.lint.usage.customSynopsis=@|fg(yellow) crowdin |@(@|fg(yellow) download|@|@|fg(yellow) pull|@) [CONFIG OPTIONS] [OPTIONS]
 
+# CROWDIN LIST COMMAND
+crowdin.list.usage.plain=Provide plain, processable output
+
 # CROWDIN LIST PROJECT COMMAND
 crowdin.list.project.usage.description=Show a list of source files in the current project
 crowdin.list.project.usage.customSynopsis=@|fg(yellow) crowdin list project|@ [CONFIG OPTIONS] [OPTIONS]

--- a/src/test/java/com/crowdin/cli/commands/actions/DownloadActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/DownloadActionTest.java
@@ -79,7 +79,7 @@ public class DownloadActionTest {
                 return new ArrayList<>();
             }));
 
-        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null);
+        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -128,7 +128,7 @@ public class DownloadActionTest {
                 }};
             }));
 
-        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null);
+        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -186,7 +186,7 @@ public class DownloadActionTest {
                     }};
                 }));
 
-        Action action = new DownloadAction(files, false, null, null, false, false, null, true, true);
+        Action action = new DownloadAction(files, false, null, null, false, false, null, true, true, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -245,7 +245,7 @@ public class DownloadActionTest {
                 }};
             }));
 
-        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null);
+        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -305,7 +305,7 @@ public class DownloadActionTest {
                 }};
             }));
 
-        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null);
+        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -365,7 +365,7 @@ public class DownloadActionTest {
                 }};
             }));
 
-        Action action = new DownloadAction(files, false, null, null, false, true, null, null, null);
+        Action action = new DownloadAction(files, false, null, null, false, true, null, null, null, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -426,7 +426,7 @@ public class DownloadActionTest {
                     }};
                 }));
 
-        Action action = new DownloadAction(files, false, null, null, false, true, null, null, null);
+        Action action = new DownloadAction(files, false, null, null, false, true, null, null, null, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -470,7 +470,7 @@ public class DownloadActionTest {
 
         FilesInterface files = mock(FilesInterface.class);
 
-        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null);
+        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null, false);
         assertThrows(RuntimeException.class, () -> action.act(pb, client));
 
         verify(client).downloadFullProject();
@@ -495,7 +495,7 @@ public class DownloadActionTest {
 
         FilesInterface files = mock(FilesInterface.class);
 
-        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null);
+        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null, false);
         assertThrows(RuntimeException.class, () -> action.act(pb, client));
 
         verify(client).downloadFullProject();
@@ -540,7 +540,7 @@ public class DownloadActionTest {
         doThrow(IOException.class)
             .when(files).deleteFile(any());
 
-        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null);
+        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null, false);
         assertThrows(RuntimeException.class, () -> action.act(pb, client));
 
         verify(client).downloadFullProject();
@@ -584,7 +584,7 @@ public class DownloadActionTest {
 
         FilesInterface files = mock(FilesInterface.class);
 
-        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null);
+        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null, false);
         assertThrows(RuntimeException.class, () -> action.act(pb, client));
 
         verify(client).downloadFullProject();
@@ -621,7 +621,7 @@ public class DownloadActionTest {
             .when(files)
                 .writeToFile(any(), any());
 
-        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null);
+        Action action = new DownloadAction(files, false, null, null, false, false, null, null, null, false);
         assertThrows(RuntimeException.class, () -> action.act(pb, client));
 
         verify(client).downloadFullProject();
@@ -644,7 +644,7 @@ public class DownloadActionTest {
 
         FilesInterface files = mock(FilesInterface.class);
 
-        Action action = new DownloadAction(files, false, null, null, false, false, true, true, null);
+        Action action = new DownloadAction(files, false, null, null, false, false, true, true, null, false);
         assertThrows(RuntimeException.class, () -> action.act(pb, client));
 
         verifyZeroInteractions(client);

--- a/src/test/java/com/crowdin/cli/commands/actions/ListProjectActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/ListProjectActionTest.java
@@ -40,7 +40,7 @@ public class ListProjectActionTest {
             .thenReturn(ProjectBuilder.emptyProject(Long.parseLong(pb.getProjectId()))
                 .addFile("first.po", "gettext", 101L, null, null).build());
 
-        Action action = new ListProjectAction(false, null, true);
+        Action action = new ListProjectAction(false, null, true, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -58,7 +58,7 @@ public class ListProjectActionTest {
             .thenReturn(ProjectBuilder.emptyProject(Long.parseLong(pb.getProjectId()))
                 .addFile("first.po", "gettext", 101L, null, null).build());
 
-        Action action = new ListProjectAction(false, "nonexistentBranch", false);
+        Action action = new ListProjectAction(false, "nonexistentBranch", false, false);
         assertThrows(RuntimeException.class, () -> action.act(pb, client));
 
         verify(client).downloadFullProject();
@@ -77,7 +77,7 @@ public class ListProjectActionTest {
                 .addFile("first.po", "gettext", 101L, null, null)
                 .addBranches(1L, "existentBranch").build());
 
-        Action action = new ListProjectAction(false, "existentBranch", false);
+        Action action = new ListProjectAction(false, "existentBranch", false, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();

--- a/src/test/java/com/crowdin/cli/commands/actions/ListSourcesActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/ListSourcesActionTest.java
@@ -38,7 +38,7 @@ public class ListSourcesActionTest {
         when(client.downloadProjectWithLanguages())
             .thenReturn(ProjectBuilder.emptyProject(Long.parseLong(pb.getProjectId())).build());
 
-        Action action = new ListSourcesAction(false, false);
+        Action action = new ListSourcesAction(false, false, false);
         action.act(pb, client);
 
         verify(client).downloadProjectWithLanguages();
@@ -55,7 +55,7 @@ public class ListSourcesActionTest {
         when(client.downloadProjectWithLanguages())
                 .thenReturn(ProjectBuilder.emptyProject(Long.parseLong(pb.getProjectId())).build());
 
-        Action action = new ListSourcesAction(false, false);
+        Action action = new ListSourcesAction(false, false, false);
         action.act(pb, client);
         pb.setPreserveHierarchy(true);
         action.act(pb, client);

--- a/src/test/java/com/crowdin/cli/commands/actions/ListTranslationsActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/ListTranslationsActionTest.java
@@ -41,7 +41,7 @@ public class ListTranslationsActionTest {
                 .thenReturn(ProjectBuilder.emptyProject(Long.parseLong(pb.getProjectId()))
                         .addFile("first.po", "gettext", 101L, null, null).build());
 
-        Action action = new ListTranslationsAction(false, false, false);
+        Action action = new ListTranslationsAction(false, false, false, false);
         action.act(pb, client);
 
         verify(client).downloadProjectWithLanguages();

--- a/src/test/java/com/crowdin/cli/commands/actions/UploadSourcesActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/UploadSourcesActionTest.java
@@ -46,7 +46,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.po"), any()))
             .thenReturn(1L);
 
-        Action action = new UploadSourcesAction(null, false, true, false);
+        Action action = new UploadSourcesAction(null, false, true, false, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -92,7 +92,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("third.po"), any()))
             .thenReturn(3L);
 
-        Action action = new UploadSourcesAction(null, false, true, false);
+        Action action = new UploadSourcesAction(null, false, true, false, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -160,7 +160,7 @@ public class UploadSourcesActionTest {
         when(client.addBranch(addBranchRequest))
             .thenReturn(branch);
 
-        Action action = new UploadSourcesAction("newBranch", false, true, false);
+        Action action = new UploadSourcesAction("newBranch", false, true, false, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -196,7 +196,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.po"), any()))
             .thenReturn(1L);
 
-        Action action = new UploadSourcesAction("newBranch", false, true, false);
+        Action action = new UploadSourcesAction("newBranch", false, true, false, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -230,7 +230,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.po"), any()))
             .thenReturn(1L);
 
-        Action action = new UploadSourcesAction(null, false, true, false);
+        Action action = new UploadSourcesAction(null, false, true, false, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -266,7 +266,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.po"), any()))
             .thenReturn(1L);
 
-        Action action = new UploadSourcesAction(null, false, true, false);
+        Action action = new UploadSourcesAction(null, false, true, false, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -301,7 +301,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("last.po"), any()))
             .thenReturn(1L);
 
-        Action action = new UploadSourcesAction(null, false, true, false);
+        Action action = new UploadSourcesAction(null, false, true, false, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -339,7 +339,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("second.po"), any()))
             .thenReturn(2L);
 
-        Action action = new UploadSourcesAction(null, false, true, false);
+        Action action = new UploadSourcesAction(null, false, true, false, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -387,7 +387,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.csv"), any()))
                 .thenReturn(1L);
 
-        Action action = new UploadSourcesAction(null, false, true, false);
+        Action action = new UploadSourcesAction(null, false, true, false, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();

--- a/src/test/java/com/crowdin/cli/commands/actions/UploadTranslationsActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/UploadTranslationsActionTest.java
@@ -48,7 +48,7 @@ public class UploadTranslationsActionTest {
         when(client.uploadStorage(eq("first.po-CR-uk-UA"), any()))
             .thenReturn(1L);
 
-        Action action = new UploadTranslationsAction(false, null, null, false, false, false);
+        Action action = new UploadTranslationsAction(false, null, null, false, false, false, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -81,7 +81,7 @@ public class UploadTranslationsActionTest {
         when(client.uploadStorage(eq("first.po-CR-ru-RU"), any()))
             .thenReturn(2L);
 
-        Action action = new UploadTranslationsAction(false, null, null, false, false, false);
+        Action action = new UploadTranslationsAction(false, null, null, false, false, false, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -116,7 +116,7 @@ public class UploadTranslationsActionTest {
         when(client.downloadFullProject())
             .thenReturn(ProjectBuilder.emptyProject(Long.parseLong(pb.getProjectId())).build());
 
-        Action action = new UploadTranslationsAction(false, null, null, false, false, false);
+        Action action = new UploadTranslationsAction(false, null, null, false, false, false, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();
@@ -139,7 +139,7 @@ public class UploadTranslationsActionTest {
         when(client.uploadStorage(eq("first.csv-CR"), any()))
             .thenReturn(1L);
 
-        Action action = new UploadTranslationsAction(false, null, null, false, false, false);
+        Action action = new UploadTranslationsAction(false, null, null, false, false, false, false);
         action.act(pb, client);
 
         verify(client).downloadFullProject();


### PR DESCRIPTION
* allow adding --plain to process output of crowdin-cli in scripts
* Disable new version notification
* disable all cosmetical output
* adjust tests for new method signature

We're using the output of crowdin list in a python script to manage committing the translations across multiple repos. For that we need processable, plain output.