### PR TITLE
AUR package: remove gradle dependency usage

### DIFF
--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -6,7 +6,7 @@ pkgdesc="Command line tool that allows you to manage and synchronize localizatio
 url="https://support.crowdin.com/cli-tool/"
 license=('MIT')
 depends=('java-runtime>=8')
-makedepends=('git' 'java-environment>=8' 'gradle' 'grep' 'awk')
+makedepends=('git' 'java-environment>=8' 'grep' 'awk')
 conflicts=('crowdin-cli-bin')
 arch=('any')
 md5sums=('SKIP' 'b018bcf51df64a8e68450cd7ac0e3838')
@@ -18,8 +18,8 @@ source=(
 
 build() {
   cd "$srcdir/$pkgname"
-  gradle shadowJar
-  gradle properties --no-daemon --console=plain -q | grep "^version:" | awk '{printf $2}' > _pkgBuildVersion
+  ./gradlew shadowJar
+  ./gradlew properties --no-daemon --console=plain -q | grep "^version:" | awk '{printf $2}' > _pkgBuildVersion
   java -cp "build/libs/crowdin-cli-$(cat _pkgBuildVersion).jar" picocli.AutoComplete --force com.crowdin.cli.commands.picocli.RootCommand
 }
 


### PR DESCRIPTION
Arch Linux updated Gradle to version 7 and crowdin-cli doesn't build with this version yet (fails with an error).

Looks like we can just call `gradlew` script instead of a 3rd party provided Gradle installation, which will pull the right version of Gradle for the project.

P.S. I've already pushed this changed to AUR