### PR TITLE
Fixes for '--delete-obsolete' param:

### DIFF
--- a/src/main/java/com/crowdin/cli/commands/Actions.java
+++ b/src/main/java/com/crowdin/cli/commands/Actions.java
@@ -35,7 +35,7 @@ public interface Actions {
         boolean noProgress, String branchName, boolean treeView, boolean plainView);
 
     NewAction<PropertiesWithFiles, ProjectClient> listSources(
-        boolean noProgress, boolean treeView, boolean plainView);
+        boolean deleteObsolete, String branchName, boolean noProgress, boolean treeView, boolean plainView);
 
     NewAction<PropertiesWithFiles, ProjectClient> listTranslations(
         boolean noProgress, boolean treeView, boolean isLocal, boolean plainView, boolean useServerSources, boolean withInContextLang);

--- a/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
@@ -51,9 +51,9 @@ public class CliActions implements Actions {
 
     @Override
     public NewAction<PropertiesWithFiles, ProjectClient> listSources(
-        boolean noProgress, boolean treeView, boolean plainView
+        boolean deleteObsolete, String branchName, boolean noProgress, boolean treeView, boolean plainView
     ) {
-        return new ListSourcesAction(noProgress, treeView, plainView);
+        return new ListSourcesAction(deleteObsolete, branchName, noProgress, treeView, plainView);
     }
 
     @Override

--- a/src/main/java/com/crowdin/cli/commands/actions/ListSourcesAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/ListSourcesAction.java
@@ -1,21 +1,33 @@
 package com.crowdin.cli.commands.actions;
 
 import com.crowdin.cli.client.CrowdinProject;
+import com.crowdin.cli.client.CrowdinProjectFull;
 import com.crowdin.cli.client.ProjectClient;
 import com.crowdin.cli.commands.NewAction;
 import com.crowdin.cli.commands.Outputter;
+import com.crowdin.cli.commands.functionality.DryrunObsoleteSources;
 import com.crowdin.cli.commands.functionality.DryrunSources;
 import com.crowdin.cli.properties.PropertiesWithFiles;
 import com.crowdin.cli.utils.PlaceholderUtil;
 import com.crowdin.cli.utils.console.ConsoleSpinner;
+import com.crowdin.client.sourcefiles.model.Branch;
+
+import java.util.Optional;
+
+import static com.crowdin.cli.BaseCli.RESOURCE_BUNDLE;
+import static com.crowdin.cli.utils.console.ExecutionStatus.WARNING;
 
 class ListSourcesAction implements NewAction<PropertiesWithFiles, ProjectClient> {
 
+    private boolean deleteObsolete;
+    private String branchName;
     private boolean noProgress;
     private boolean treeView;
     private boolean plainView;
 
-    public ListSourcesAction(boolean noProgress, boolean treeView, boolean plainView) {
+    public ListSourcesAction(boolean deleteObsolete, String branchName, boolean noProgress, boolean treeView, boolean plainView) {
+        this.deleteObsolete = deleteObsolete && !plainView;
+        this.branchName = branchName;
         this.noProgress = noProgress || plainView;
         this.treeView = treeView;
         this.plainView = plainView;
@@ -23,11 +35,28 @@ class ListSourcesAction implements NewAction<PropertiesWithFiles, ProjectClient>
 
     @Override
     public void act(Outputter out, PropertiesWithFiles pb, ProjectClient client) {
-        CrowdinProject project = ConsoleSpinner
-            .execute(out, "message.spinner.fetching_project_info", "error.collect_project_info",
-                this.noProgress, this.plainView, client::downloadProjectWithLanguages);
+        CrowdinProject project = ConsoleSpinner.execute(out, "message.spinner.fetching_project_info", "error.collect_project_info",
+            this.noProgress, this.plainView, (deleteObsolete) ? client::downloadFullProject : client::downloadProjectWithLanguages);
         PlaceholderUtil placeholderUtil = new PlaceholderUtil(project.getSupportedLanguages(), project.getProjectLanguages(false), pb.getBasePath());
 
+        if (!project.isManagerAccess() && deleteObsolete) {
+            if (!plainView) {
+                out.println(WARNING.withIcon(RESOURCE_BUNDLE.getString("message.no_manager_access_in_upload_sources_dryrun")));
+                return;
+            } else {
+                throw new RuntimeException(RESOURCE_BUNDLE.getString("message.no_manager_access_in_upload_sources_dryrun"));
+            }
+        }
+
+        if (deleteObsolete) {
+            CrowdinProjectFull projectFull = (CrowdinProjectFull) project;
+            Long branchId = Optional.ofNullable(branchName)
+                .map(br -> projectFull.findBranchByName(br)
+                    .orElseThrow(() -> new RuntimeException(RESOURCE_BUNDLE.getString("error.not_found_branch"))))
+                .map(Branch::getId)
+                .orElse(null);
+            (new DryrunObsoleteSources(pb, placeholderUtil, projectFull.getDirectories(branchId), projectFull.getFiles(branchId))).run(out, treeView, plainView);
+        }
         (new DryrunSources(pb, placeholderUtil)).run(out, treeView, plainView);
     }
 }

--- a/src/main/java/com/crowdin/cli/commands/actions/UploadSourcesAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/UploadSourcesAction.java
@@ -130,14 +130,6 @@ class UploadSourcesAction implements NewAction<PropertiesWithFiles, ProjectClien
                 List<String> sources = SourcesUtils.getFiles(pb.getBasePath(), file.getSource(), file.getIgnore(), placeholderUtil)
                     .map(File::getAbsolutePath)
                     .collect(Collectors.toList());
-                if (sources.isEmpty()) {
-                    if (!plainView) {
-                        errorsPresented.set(true);
-                        throw new RuntimeException(String.format(RESOURCE_BUNDLE.getString("error.no_sources"), file.getSource()));
-                    } else {
-                        return;
-                    }
-                }
                 String commonPath =
                     (pb.getPreserveHierarchy()) ? "" : SourcesUtils.getCommonPath(sources, pb.getBasePath());
                 if (deleteObsolete) {
@@ -149,6 +141,14 @@ class UploadSourcesAction implements NewAction<PropertiesWithFiles, ProjectClien
                         deleteObsoleteProjectFilesSubAction.act(file.getDest(), file.getTranslation(), filesToUpdate);
                     } else {
                         deleteObsoleteProjectFilesSubAction.act(file.getSource(), file.getIgnore(), file.getTranslation(), filesToUpdate);
+                    }
+                }
+                if (sources.isEmpty()) {
+                    if (!plainView) {
+                        errorsPresented.set(true);
+                        throw new RuntimeException(String.format(RESOURCE_BUNDLE.getString("error.no_sources"), file.getSource()));
+                    } else {
+                        return;
                     }
                 }
                 List<Runnable> taskss = sources.stream()

--- a/src/main/java/com/crowdin/cli/commands/functionality/DryrunObsoleteSources.java
+++ b/src/main/java/com/crowdin/cli/commands/functionality/DryrunObsoleteSources.java
@@ -1,0 +1,58 @@
+package com.crowdin.cli.commands.functionality;
+
+import com.crowdin.cli.properties.FileBean;
+import com.crowdin.cli.properties.PropertiesWithFiles;
+import com.crowdin.cli.utils.PlaceholderUtil;
+import com.crowdin.cli.utils.Utils;
+import com.crowdin.client.sourcefiles.model.Directory;
+import com.crowdin.client.sourcefiles.model.File;
+import lombok.NonNull;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class DryrunObsoleteSources extends Dryrun {
+
+    private PropertiesWithFiles pb;
+    private PlaceholderUtil placeholderUtil;
+    private Map<Long, Directory> directories;
+    private List<File> files;
+
+    public DryrunObsoleteSources(@NonNull PropertiesWithFiles pb, @NonNull PlaceholderUtil placeholderUtil, @NonNull Map<Long, Directory> directories, @NonNull List<File> files) {
+        super("message.obsolete_file");
+        this.pb = pb;
+        this.placeholderUtil = placeholderUtil;
+        this.directories = directories;
+        this.files = files;
+    }
+
+    @Override
+    protected List<String> getFiles() {
+        Map<String, com.crowdin.client.sourcefiles.model.File> projectFiles = ProjectFilesUtils.buildFilePaths(directories, files);
+        List<String> obsoleteFilesResult = new ArrayList<>();
+        for (FileBean file : pb.getFiles()) {
+            List<String> sources = SourcesUtils.getFiles(pb.getBasePath(), file.getSource(), file.getIgnore(), placeholderUtil)
+                .map(java.io.File::getAbsolutePath)
+                .collect(Collectors.toList());
+            String commonPath =
+                (pb.getPreserveHierarchy()) ? "" : SourcesUtils.getCommonPath(sources, pb.getBasePath());
+            List<String> filesToUpdate = sources.stream()
+                .map(source -> (file.getDest() != null)
+                    ? PropertiesBeanUtils.prepareDest(file.getDest(), StringUtils.removeStart(source, pb.getBasePath()), placeholderUtil)
+                    : StringUtils.removeStart(source, pb.getBasePath() + commonPath))
+                .map(Utils::noSepAtStart)
+                .collect(Collectors.toList());
+
+            String pattern = (file.getDest() != null) ? file.getDest() : file.getSource();
+            List<String> ignorePatterns = (file.getDest() != null) ? null : file.getIgnore();
+
+            Map<String, File> obsoleteFiles = ObsoleteSourcesUtils.findObsoleteProjectFiles(projectFiles, pb.getPreserveHierarchy(), filesToUpdate, pattern, file.getTranslation(), ignorePatterns);
+            obsoleteFilesResult.addAll(obsoleteFiles.keySet());
+        }
+
+        return obsoleteFilesResult;
+    }
+}

--- a/src/main/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtils.java
+++ b/src/main/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtils.java
@@ -1,0 +1,79 @@
+package com.crowdin.cli.commands.functionality;
+
+import com.crowdin.cli.utils.Utils;
+import com.crowdin.client.sourcefiles.model.File;
+import lombok.NonNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class ObsoleteSourcesUtils {
+
+    public static Map<String, File> findObsoleteProjectFiles(
+        @NonNull Map<String, File> projectFiles, boolean preserveHierarchy,
+        @NonNull List<String> filesToUpload, @NonNull String pattern, @NonNull String exportPattern, List<String> ignorePattern
+    ) {
+        Predicate<String> patternCheck =
+            ProjectFilesUtils.isProjectFilePathSatisfiesPatterns(pattern, ignorePattern, preserveHierarchy);
+        return projectFiles.entrySet().stream()
+            .filter(entry -> patternCheck.test(entry.getKey()) && checkExportPattern(exportPattern, entry.getValue()))
+            .filter(entry -> isFileDontHaveUpdate(filesToUpload, entry.getKey(), preserveHierarchy))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static boolean checkExportPattern(String exportPattern, File file) {
+        String fileExportPattern = ProjectFilesUtils.getExportPattern(file.getExportOptions());
+        return exportPattern.equals(fileExportPattern != null ? Utils.normalizePath(fileExportPattern) : null);
+    }
+
+    public static SortedMap<String, Long> findObsoleteProjectDirectories(
+        @NonNull Map<String, File> projectFiles, @NonNull Map<String, Long> directoryIds,
+        @NonNull List<String> filesToUpload, @NonNull Map<String, File> obsoleteDeletedProjectFiles
+    ) {
+        List<String> upToDateDirs = filesToUpload.stream()
+            .map(Utils::getParentDirectory)
+            .collect(Collectors.toList());
+        upToDateDirs.addAll(projectFiles.keySet().stream()
+            .filter(projectFile -> !obsoleteDeletedProjectFiles.containsKey(projectFile))
+            .map(Utils::getParentDirectory)
+            .collect(Collectors.toSet()));
+        for (int i = 0; i < upToDateDirs.size(); i++) {
+            String parentDir = Utils.getParentDirectory(upToDateDirs.get(i));
+            if (!upToDateDirs.contains(parentDir)) {
+                upToDateDirs.add(parentDir);
+            }
+        }
+
+        List<String> obsoleteDirPathes = obsoleteDeletedProjectFiles.keySet().stream()
+            .map(Utils::getParentDirectory)
+            .distinct()
+            .collect(Collectors.toList());
+        for (int i = 0; i < obsoleteDirPathes.size(); i++) {
+            String parentDir = Utils.getParentDirectory(obsoleteDirPathes.get(i));
+            if (!obsoleteDirPathes.contains(parentDir)) {
+                obsoleteDirPathes.add(parentDir);
+            }
+        }
+        obsoleteDirPathes.remove(Utils.PATH_SEPARATOR);
+
+        SortedMap<String, Long> obsoleteDirs = new TreeMap<>(Collections.reverseOrder());
+        for (String obsoleteDirPath : obsoleteDirPathes) {
+            if (!upToDateDirs.contains(obsoleteDirPath)) {
+                obsoleteDirs.put(obsoleteDirPath, directoryIds.get(obsoleteDirPath));
+            }
+        }
+        return obsoleteDirs;
+    }
+
+    private static boolean isFileDontHaveUpdate(List<String> filesToUpload, String filePath, boolean preserveHierarchy) {
+        String filePathRegex = "^" + (preserveHierarchy ? "" : Utils.PRESERVE_HIERARCHY_REGEX_PART) + Utils.regexPath(filePath) + "$";
+        return filesToUpload.stream()
+            .noneMatch(Pattern.compile(filePathRegex).asPredicate());
+    }
+}

--- a/src/main/java/com/crowdin/cli/commands/picocli/ListSourcesSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/ListSourcesSubcommand.java
@@ -19,7 +19,7 @@ class ListSourcesSubcommand extends ActCommandWithFiles {
 
     @Override
     protected NewAction<PropertiesWithFiles, ProjectClient> getAction(Actions actions) {
-        return actions.listSources(this.noProgress, this.treeView, this.plainView);
+        return actions.listSources(false, null, this.noProgress, this.treeView, this.plainView);
     }
 
     @CommandLine.Option(names = {"--plain"}, descriptionKey = "crowdin.list.usage.plain")

--- a/src/main/java/com/crowdin/cli/commands/picocli/UploadSourcesCommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/UploadSourcesCommand.java
@@ -35,7 +35,7 @@ class UploadSourcesCommand extends ActCommandWithFiles {
     @Override
     protected NewAction<PropertiesWithFiles, ProjectClient> getAction(Actions actions) {
         return (dryrun)
-            ? actions.listSources(this.noProgress, this.treeView, plainView)
+            ? actions.listSources(this.deleteObsolete, this.branch, this.noProgress, this.treeView, plainView)
             : actions.uploadSources(this.branch, this.deleteObsolete, this.noProgress, this.autoUpdate, debug, plainView);
     }
 

--- a/src/main/java/com/crowdin/cli/utils/Utils.java
+++ b/src/main/java/com/crowdin/cli/utils/Utils.java
@@ -40,6 +40,8 @@ public class Utils {
      */
     public static final String PATH_SEPARATOR_REGEX = "\\".equals(PATH_SEPARATOR) ? "\\\\" : PATH_SEPARATOR;
 
+    public static final String PRESERVE_HIERARCHY_REGEX_PART = "(.*" + Utils.PATH_SEPARATOR_REGEX + ")?";
+
     private static final ResourceBundle CROWDIN_PROPERTIES = ResourceBundle.getBundle("crowdin");
 
     public static String getAppName() {

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -405,6 +405,7 @@ message.target_success=@|fg(green),bold '%s'|@ @|fg(green) target successfully d
 message.no_targets_to_exec=Couldn't find any targets to download
 message.no_target_to_exec=Couldn't find @|bold '%s'|@ target to download
 message.description=%s @|bold '%s'|@
+message.obsolete_file=Obsolete file @|bold '%s'|@
 
 message.download_sources.preserve_hierarchy_warning=Because the @|bold 'preserve_hierarchy'|@ parameter is set to 'false':\n\t- CLI might download some unexpected files that match the pattern;\n\t- Source file hierarchy may not be preserved and will be the same as in Crowdin.
 message.download_translations.preserve_hierarchy_warning=Because the @|bold 'preserve_hierarchy'|@ parameter is set to 'false' CLI might download some unexpected files that match the pattern
@@ -445,6 +446,7 @@ message.html_page.body=<link href="https://fonts.googleapis.com/css2?family=Open
 
 message.no_manager_access=You need to have @|yellow manager access|@ in the project to perform this action
 message.no_manager_access_in_upload_sources=You need to have @|yellow manager access|@ in the project to apply 'excluded-languages' or/and 'delete-obsolete' options
+message.no_manager_access_in_upload_sources_dryrun=You need to have @|yellow manager access|@ in the project to apply 'delete-obsolete' options
 
 message.warning.not_yml=File @|bold '%s'|@ is not a YAML or YML file
 message.warning.browser_not_found=Error opening web browser. Please open the following link manually:\n@|bold %s|@
@@ -475,6 +477,6 @@ message.tree.win.last_elem=@|cyan \u2514\u2500\u0020|@
 message.tree.win.dir=@|cyan \u2502\u0020\u0020|@
 message.tree.win.last_dir=@|cyan \u0020\u0020\u0020|@
 
-message.color.green=@|green %s|@
+message.color.green=@|green,bold %s|@
 message.color.yellow=@|yellow %s|@
 message.color.red=@|red %s|@

--- a/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
@@ -34,7 +34,7 @@ public class CliActionsTest {
 
     @Test
     public void testListSources() {
-        assertNotNull(actions.listSources(false, false, false));
+        assertNotNull(actions.listSources(false, null, false, false, false));
     }
 
     @Test

--- a/src/test/java/com/crowdin/cli/commands/actions/ListSourcesActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/ListSourcesActionTest.java
@@ -43,7 +43,7 @@ public class ListSourcesActionTest {
         when(client.downloadProjectWithLanguages())
             .thenReturn(ProjectBuilder.emptyProject(Long.parseLong(pb.getProjectId())).build());
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new ListSourcesAction(false, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new ListSourcesAction(false, null, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadProjectWithLanguages();
@@ -60,7 +60,7 @@ public class ListSourcesActionTest {
         when(client.downloadProjectWithLanguages())
                 .thenReturn(ProjectBuilder.emptyProject(Long.parseLong(pb.getProjectId())).build());
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new ListSourcesAction(false, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new ListSourcesAction(false, null, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
         pb.setPreserveHierarchy(true);
         action.act(Outputter.getDefault(), pb, client);

--- a/src/test/java/com/crowdin/cli/commands/picocli/ListSourcesSubcommandTest.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/ListSourcesSubcommandTest.java
@@ -2,6 +2,7 @@ package com.crowdin.cli.commands.picocli;
 
 import org.junit.jupiter.api.Test;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.verify;
 
@@ -12,7 +13,7 @@ public class ListSourcesSubcommandTest extends PicocliTestUtils {
     public void testListSources() {
         this.execute(CommandNames.LIST, CommandNames.LIST_SOURCES);
         verify(actionsMock)
-            .listSources(anyBoolean(), anyBoolean(), anyBoolean());
+            .listSources(anyBoolean(), any(), anyBoolean(), anyBoolean(), anyBoolean());
         this.check(true);
     }
 }

--- a/src/test/java/com/crowdin/cli/commands/picocli/PicocliTestUtils.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/PicocliTestUtils.java
@@ -66,7 +66,7 @@ public class PicocliTestUtils {
             .thenReturn(actionMock);
         when(actionsMock.listProject(anyBoolean(), any(), anyBoolean(), anyBoolean()))
             .thenReturn(actionMock);
-        when(actionsMock.listSources(anyBoolean(), anyBoolean(), anyBoolean()))
+        when(actionsMock.listSources(anyBoolean(), any(), anyBoolean(), anyBoolean(), anyBoolean()))
             .thenReturn(actionMock);
         when(actionsMock.listTranslations(anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean()))
             .thenReturn(actionMock);

--- a/src/test/java/com/crowdin/cli/commands/picocli/UploadSourcesCommandTest.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/UploadSourcesCommandTest.java
@@ -20,7 +20,7 @@ public class UploadSourcesCommandTest extends PicocliTestUtils {
     public void testUploadSourcesDryrun() {
         this.execute(CommandNames.UPLOAD, "--dryrun");
         verify(actionsMock)
-            .listSources(anyBoolean(), anyBoolean(), anyBoolean());
+            .listSources(anyBoolean(), any(), anyBoolean(), anyBoolean(), anyBoolean());
         this.check(true);
     }
 }


### PR DESCRIPTION
- Add showing obsolete files list to dryrun option
- Move out logic for creating list of obsolete files
- Make map of obsolete directories sorted