### PR TITLE
Version 3.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.6.5]
+
+### Added
+
+- Add '--branch' option for 'status' commands ([#374](https://github.com/crowdin/crowdin-cli/pull/374))
+- Add '--delete-obsolete' option to 'upload sources' command ([#374](https://github.com/crowdin/crowdin-cli/pull/374))
+- Add '--label' option to 'string add' and 'string edit' commands ([#384](https://github.com/crowdin/crowdin-cli/pull/384))
+
+### Fixed
+
+- Fix uploading XLSX files ([#377](https://github.com/crowdin/crowdin-cli/pull/377))
+- Fix not showing all omitted files and improve building export patterns ([#378](https://github.com/crowdin/crowdin-cli/pull/378))
+
 ## [3.6.4]
 
 ### Updated

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 apply plugin: 'checkstyle'
 
 group 'com.crowdin'
-version '3.6.4'
+version '3.6.5'
 
 sourceCompatibility = 1.8
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowdin/cli",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/crowdin/crowdin-cli.git"
   },
-  "version": "3.6.4",
+  "version": "3.6.5",
   "jdeploy": {
     "jar": "dist/crowdin-cli.jar"
   },

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Senya <senya at riseup.net>
 pkgname=crowdin-cli
-pkgver=3.6.4
+pkgver=3.6.5
 pkgrel=1
 pkgdesc="Command line tool that allows you to manage and synchronize localization resources with your Crowdin project"
 url="https://support.crowdin.com/cli-tool/"

--- a/src/main/resources/crowdin.properties
+++ b/src/main/resources/crowdin.properties
@@ -1,5 +1,5 @@
 application.name=crowdin-cli
-application.version=3.6.4
+application.version=3.6.5
 application.base_url=https://api.crowdin.com
 application.user_agent=crowdin-java-cli
 application.version_file_url=https://downloads.crowdin.com/cli/v3/version.txt


### PR DESCRIPTION
### Added

- Add `--branch` option for `status` commands ([#374](https://github.com/crowdin/crowdin-cli/pull/374))
- Add `--delete-obsolete` option to `upload sources` command ([#374](https://github.com/crowdin/crowdin-cli/pull/374))
- Add `--label` option to `string add` and `string edit` commands ([#384](https://github.com/crowdin/crowdin-cli/pull/384))

### Fixed

- Fix uploading XLSX files ([#377](https://github.com/crowdin/crowdin-cli/pull/377))
- Fix not showing all omitted files and improve building export patterns ([#378](https://github.com/crowdin/crowdin-cli/pull/378))
