### PR TITLE
Version 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.7.0]
+
+### Added
+
+- Add new 'branch' subcommands ([#393](https://github.com/crowdin/crowdin-cli/pull/393))
+- Add 'custom_segmentation' field support in config ([#389](https://github.com/crowdin/crowdin-cli/pull/389))
+- Add '--branch' param for 'string list' command ([#389](https://github.com/crowdin/crowdin-cli/pull/389))
+
+### Updated
+
+- Improve '--delete-obsolete' logic ([#394](https://github.com/crowdin/crowdin-cli/pull/394))
+- Remove requirement for 'files' block for some commands ([#393](https://github.com/crowdin/crowdin-cli/pull/393))
+
+### Fixed
+
+- Fix showing New version banner with '--plain' param ([#389](https://github.com/crowdin/crowdin-cli/pull/389))
+- Fix message in authorizing via browser ([#389](https://github.com/crowdin/crowdin-cli/pull/389))
+- Fix 'dest' ([#396](https://github.com/crowdin/crowdin-cli/pull/396))
+- Fix exception handling at uploading file to storage in 'upload source' action ([#389](https://github.com/crowdin/crowdin-cli/pull/389))
+
 ## [3.6.5]
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 apply plugin: 'checkstyle'
 
 group 'com.crowdin'
-version '3.6.5'
+version '3.7.0'
 
 sourceCompatibility = 1.8
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowdin/cli",
-  "version": "3.6.5",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/crowdin/crowdin-cli.git"
   },
-  "version": "3.6.5",
+  "version": "3.7.0",
   "jdeploy": {
     "jar": "dist/crowdin-cli.jar"
   },

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Senya <senya at riseup.net>
 pkgname=crowdin-cli
-pkgver=3.6.5
+pkgver=3.7.0
 pkgrel=1
 pkgdesc="Command line tool that allows you to manage and synchronize localization resources with your Crowdin project"
 url="https://support.crowdin.com/cli-tool/"

--- a/src/main/resources/crowdin.properties
+++ b/src/main/resources/crowdin.properties
@@ -1,5 +1,5 @@
 application.name=crowdin-cli
-application.version=3.6.5
+application.version=3.7.0
 application.base_url=https://api.crowdin.com
 application.user_agent=crowdin-java-cli
 application.version_file_url=https://downloads.crowdin.com/cli/v3/version.txt


### PR DESCRIPTION
### Added

- Add new `branch` subcommands ([#393](https://github.com/crowdin/crowdin-cli/pull/393))
- Add `custom_segmentation` field support in config ([#389](https://github.com/crowdin/crowdin-cli/pull/389))
- Add `--branch` param for `string list` command ([#389](https://github.com/crowdin/crowdin-cli/pull/389))

### Updated

- Improve `--delete-obsolete` logic ([#394](https://github.com/crowdin/crowdin-cli/pull/394))
- Remove requirement for `files` block for some commands ([#393](https://github.com/crowdin/crowdin-cli/pull/393))

### Fixed

- Fix showing New version banner with `--plain` param ([#389](https://github.com/crowdin/crowdin-cli/pull/389))
- Fix message in authorizing via browser ([#389](https://github.com/crowdin/crowdin-cli/pull/389))
- Fix `dest` ([#396](https://github.com/crowdin/crowdin-cli/pull/396))
- Fix exception handling at uploading file to storage in `upload sources` action ([#389](https://github.com/crowdin/crowdin-cli/pull/389))