### PR TITLE
Version 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.7.1]
+
+### Added
+- Add 'croql' parameter to 'string list' ([#401](https://github.com/crowdin/crowdin-cli/pull/401))
+
+### Fixed
+
+- Fix selecting source files with 'dest' param for 'download sources', 'dryrun translations' and 'download' commands ([#399](https://github.com/crowdin/crowdin-cli/pull/399))
+- Little fix for 'generate' command ([#400](https://github.com/crowdin/crowdin-cli/pull/400))
+
 ## [3.7.0]
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 apply plugin: 'checkstyle'
 
 group 'com.crowdin'
-version '3.7.0'
+version '3.7.1'
 
 sourceCompatibility = 1.8
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowdin/cli",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/crowdin/crowdin-cli.git"
   },
-  "version": "3.7.0",
+  "version": "3.7.1",
   "jdeploy": {
     "jar": "dist/crowdin-cli.jar"
   },

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Senya <senya at riseup.net>
 pkgname=crowdin-cli
-pkgver=3.7.0
+pkgver=3.7.1
 pkgrel=1
 pkgdesc="Command line tool that allows you to manage and synchronize localization resources with your Crowdin project"
 url="https://support.crowdin.com/cli-tool/"

--- a/src/main/resources/crowdin.properties
+++ b/src/main/resources/crowdin.properties
@@ -1,5 +1,5 @@
 application.name=crowdin-cli
-application.version=3.7.0
+application.version=3.7.1
 application.base_url=https://api.crowdin.com
 application.user_agent=crowdin-java-cli
 application.version_file_url=https://downloads.crowdin.com/cli/v3/version.txt


### PR DESCRIPTION
### Added
- Add 'croql' parameter to 'string list' ([#401](https://github.com/crowdin/crowdin-cli/pull/401))

### Updated
- Minor text improvement for messages.properties ([#403](https://github.com/crowdin/crowdin-cli/pull/403))

### Fixed

- Fix selecting source files with 'dest' param for 'download sources', 'dryrun translations' and 'download' commands ([#399](https://github.com/crowdin/crowdin-cli/pull/399))
- Little fix for 'generate' command ([#400](https://github.com/crowdin/crowdin-cli/pull/400))
