### PR TITLE
Version 3.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.7.2]
+
+### Updated
+
+- Add check if an archive is empty and add a message when there are no files to the 'download' command ([#406](https://github.com/crowdin/crowdin-cli/pull/406))
+- Improve timing for checking building translations ([#406](https://github.com/crowdin/crowdin-cli/pull/406))
+
+### Fixed
+
+- Fix '%original_path%' placeholder for downloading ([#406](https://github.com/crowdin/crowdin-cli/pull/406))
+
 ## [3.7.1]
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 apply plugin: 'checkstyle'
 
 group 'com.crowdin'
-version '3.7.1'
+version '3.7.2'
 
 sourceCompatibility = 1.8
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowdin/cli",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/crowdin/crowdin-cli.git"
   },
-  "version": "3.7.1",
+  "version": "3.7.2",
   "jdeploy": {
     "jar": "dist/crowdin-cli.jar"
   },

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Senya <senya at riseup.net>
 pkgname=crowdin-cli
-pkgver=3.7.1
+pkgver=3.7.2
 pkgrel=1
 pkgdesc="Command line tool that allows you to manage and synchronize localization resources with your Crowdin project"
 url="https://support.crowdin.com/cli-tool/"

--- a/src/main/resources/crowdin.properties
+++ b/src/main/resources/crowdin.properties
@@ -1,5 +1,5 @@
 application.name=crowdin-cli
-application.version=3.7.1
+application.version=3.7.2
 application.base_url=https://api.crowdin.com
 application.user_agent=crowdin-java-cli
 application.version_file_url=https://downloads.crowdin.com/cli/v3/version.txt


### PR DESCRIPTION
### Updated

- Add check if an archive is empty and add a message when there are no files to the 'download' command ([#406](https://github.com/crowdin/crowdin-cli/pull/406))
- Improve timing for checking building translations ([#406](https://github.com/crowdin/crowdin-cli/pull/406))

### Fixed

- Fix `%original_path%` placeholder for downloading ([#406](https://github.com/crowdin/crowdin-cli/pull/406))
