### PR TITLE
Update log4j to 2.17.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ repositories {
 dependencies {
     implementation 'org.json:json:20210307'
     implementation 'commons-cli:commons-cli:1.4'
-    implementation 'org.apache.logging.log4j:log4j-api:2.16.0'
-    implementation 'org.apache.logging.log4j:log4j-core:2.16.0'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.1'
+    implementation 'org.apache.logging.log4j:log4j-core:2.17.1'
     implementation 'org.yaml:snakeyaml:1.29'
     implementation 'commons-io:commons-io:2.10.0'
 


### PR DESCRIPTION
* According to https://logging.apache.org/log4j/2.x/security.html
  the version 2.16 is vulnerable against an RCE (see CVE-2021-44832)
* Despite the unknown actual vulerability in the cli3 context, it is
  still recommended to update to the latest fix