### PR TITLE
Fix installation and uninstall scripts

### DIFF
--- a/scripts/install-crowdin-cli.sh
+++ b/scripts/install-crowdin-cli.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [[ $(id -u) -ne 0 ]] ; then echo "Please run as root" ; exit 1 ; fi
 
 echo "Checking JAVA installation..."
@@ -29,13 +31,13 @@ if [[ "$_java" ]]; then
         [ -d "/usr/local/etc/bash_completion.d" ] && cp crowdin_completion /usr/local/etc/bash_completion.d/crowdin_completion
 
         sh -c "cat > /usr/local/bin/crowdin << EOF
-#!/bin/sh
+#!/bin/bash
 exec /usr/bin/java -jar '/usr/local/bin/crowdin-cli.jar' \"\\\$@\"
 EOF"
         chmod +x /usr/local/bin/crowdin
 
         sh -c "cat > /usr/local/bin/crowdin_uninstall << 'EOF'
-#!/bin/sh
+#!/bin/bash
 if [[ \$(id -u) -ne 0 ]] ; then echo \"Please run as root\" ; exit 1 ; fi
 rm -f /etc/bash_completion.d/crowdin_completion
 rm -f /usr/local/etc/bash_completion.d/crowdin_completion


### PR DESCRIPTION
* Currently, the install script is missing the hashbang completely
  and the uninstall script and crowdin link use /bin/sh
* This results in errors on a standard Ubuntu 20.04 installation:

Install:
sudo ./install-crowdin-cli.sh
[sudo] Passwort für michael:
./install-crowdin-cli.sh: 1: [[: not found
Checking JAVA installation...
-p: not found
java is /usr/bin/java
./install-crowdin-cli.sh: 8: [[: not found
Looks like JAVA is not installed. You can download it from https://www.java.com/
./install-crowdin-cli.sh: 14: [[: not found

Deinstall:
sudo /usr/local/bin/crowdin_uninstall
/usr/local/bin/crowdin_uninstall: 2: [[: not found
crowdin-cli uninstalled!

With this change, both installation and deinstallation work flawlessly