### PR TITLE
Version 3.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.7.8]
+
+### Updated
+
+- Update jDeploy to 2.0.11 ([#426](https://github.com/crowdin/crowdin-cli/pull/426))
+- Bump shelljs from 0.8.4 to 0.8.5 ([#424](https://github.com/crowdin/crowdin-cli/pull/424))
+
+### Fixed
+
+- Fix relative base paths ('.', '..') ([#432](https://github.com/crowdin/crowdin-cli/pull/432))
+- Fix 'download sources' command on Windows ([#433](https://github.com/crowdin/crowdin-cli/pull/433))
+
 ## [3.7.7]
 
 ### Updated

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 apply plugin: 'checkstyle'
 
 group 'com.crowdin'
-version '3.7.7'
+version '3.7.8'
 
 sourceCompatibility = 1.8
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowdin/cli",
-  "version": "3.7.7",
+  "version": "3.7.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/crowdin/crowdin-cli.git"
   },
-  "version": "3.7.7",
+  "version": "3.7.8",
   "jdeploy": {
     "jar": "dist/crowdin-cli.jar"
   },

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Senya <senya at riseup.net>
 pkgname=crowdin-cli
-pkgver=3.7.7
+pkgver=3.7.8
 pkgrel=1
 pkgdesc="Command line tool that allows you to manage and synchronize localization resources with your Crowdin project"
 url="https://support.crowdin.com/cli-tool/"

--- a/src/main/resources/crowdin.properties
+++ b/src/main/resources/crowdin.properties
@@ -1,5 +1,5 @@
 application.name=crowdin-cli
-application.version=3.7.7
+application.version=3.7.8
 application.base_url=https://api.crowdin.com
 application.user_agent=crowdin-java-cli
 application.version_file_url=https://downloads.crowdin.com/cli/v3/version.txt


### PR DESCRIPTION
### Updated

- Update jDeploy to 2.0.11 ([#426](https://github.com/crowdin/crowdin-cli/pull/426))
- Bump shelljs from 0.8.4 to 0.8.5 ([#424](https://github.com/crowdin/crowdin-cli/pull/424))

### Fixed

- Fix relative base paths ('.', '..') ([#432](https://github.com/crowdin/crowdin-cli/pull/432))
- Fix 'download sources' command on Windows ([#433](https://github.com/crowdin/crowdin-cli/pull/433))
