### PR TITLE
Add downloading multiple specified languages

### DIFF
--- a/src/main/java/com/crowdin/cli/commands/Actions.java
+++ b/src/main/java/com/crowdin/cli/commands/Actions.java
@@ -25,7 +25,7 @@ import java.util.Map;
 public interface Actions {
 
     NewAction<PropertiesWithFiles, ProjectClient> download(
-        FilesInterface files, boolean noProgress, String languageId, boolean pseudo, String branchName,
+        FilesInterface files, boolean noProgress, List<String> languageIds, boolean pseudo, String branchName,
         boolean ignoreMatch, boolean isVerbose, boolean plainView, boolean userServerSources
     );
 

--- a/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
@@ -28,10 +28,10 @@ public class CliActions implements Actions {
 
     @Override
     public NewAction<PropertiesWithFiles, ProjectClient> download(
-        FilesInterface files, boolean noProgress, String languageId, boolean pseudo, String branchName,
+        FilesInterface files, boolean noProgress, List<String> languageIds, boolean pseudo, String branchName,
         boolean ignoreMatch, boolean isVerbose, boolean plainView, boolean useServerSources
     ) {
-        return new DownloadAction(files, noProgress, languageId, pseudo, branchName, ignoreMatch, isVerbose, plainView, useServerSources);
+        return new DownloadAction(files, noProgress, languageIds, pseudo, branchName, ignoreMatch, isVerbose, plainView, useServerSources);
     }
 
     @Override

--- a/src/main/java/com/crowdin/cli/commands/picocli/DownloadSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/DownloadSubcommand.java
@@ -30,7 +30,7 @@ class DownloadSubcommand extends ActCommandWithFiles {
     protected boolean ignoreMatch;
 
     @CommandLine.Option(names = {"-l", "--language"}, paramLabel = "...")
-    protected String languageId;
+    protected List<String> languageIds;
 
     @CommandLine.Option(names = {"--pseudo"}, descriptionKey = "crowdin.download.pseudo")
     protected boolean pseudo;
@@ -57,7 +57,7 @@ class DownloadSubcommand extends ActCommandWithFiles {
     protected NewAction<PropertiesWithFiles, ProjectClient> getAction(Actions actions) {
         return (dryrun)
             ? actions.listTranslations(noProgress, treeView, false, plainView, all, true)
-            : actions.download(new FsFiles(), noProgress, languageId, pseudo, branchName, ignoreMatch, isVerbose, plainView, all);
+            : actions.download(new FsFiles(), noProgress, languageIds, pseudo, branchName, ignoreMatch, isVerbose, plainView, all);
     }
 
     @CommandLine.Option(names = {"--plain"}, descriptionKey = "crowdin.list.usage.plain")


### PR DESCRIPTION
- Adds the ability to download mutiple specified languages by doing, for example, `crowdin pull -l de -l ja -l he`
- I've run the unit tests and it passes, however tbh I don't really understand what's going on in the tests file so I don't know how to add a new test to check for this new feature
- Closes #427 