### PR TITLE
Version 3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.9.0]
+
+### Added
+
+- Add downloading multiple specified languages ([#493](https://github.com/crowdin/crowdin-cli/pull/493))
+- Add '--dryrun' mode to the 'download sources' command ([#485](https://github.com/crowdin/crowdin-cli/pull/485))
+- Add the `export_string_that_passed_workflow` export option support ([#487](https://github.com/crowdin/crowdin-cli/pull/487))
+- Add Unit tests for `StatusAction.java` ([#494](https://github.com/crowdin/crowdin-cli/pull/494))
+
+### Updated
+
+- Improve async progress status checking for some commands ([#478](https://github.com/crowdin/crowdin-cli/pull/478))
+- Make lint throw error with no config file ([#483](https://github.com/crowdin/crowdin-cli/pull/483))
+
+### Fixed
+
+- Fixed regex to work correctly for Windows machines ([#484](https://github.com/crowdin/crowdin-cli/pull/484))
+
 ## [3.8.1]
 
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 apply plugin: 'checkstyle'
 
 group 'com.crowdin'
-version '3.8.1'
+version '3.9.0'
 
 sourceCompatibility = 1.8
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowdin/cli",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/crowdin/crowdin-cli.git"
   },
-  "version": "3.8.1",
+  "version": "3.9.0",
   "jdeploy": {
     "jar": "dist/crowdin-cli.jar"
   },

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Senya <senya at riseup.net>
 pkgname=crowdin-cli
-pkgver=3.8.1
+pkgver=3.9.0
 pkgrel=1
 pkgdesc="Command line tool that allows you to manage and synchronize localization resources with your Crowdin project"
 url="https://support.crowdin.com/cli-tool/"

--- a/src/main/resources/crowdin.properties
+++ b/src/main/resources/crowdin.properties
@@ -1,5 +1,5 @@
 application.name=crowdin-cli
-application.version=3.8.1
+application.version=3.9.0
 application.base_url=https://api.crowdin.com
 application.user_agent=crowdin-java-cli
 application.version_file_url=https://downloads.crowdin.com/cli/v3/version.txt


### PR DESCRIPTION
### Added

- Add downloading multiple specified languages (#493)
- Add '--dryrun' mode to the 'download sources' command (#485)
- Add the `export_string_that_passed_workflow` export option support (#487)
- Add Unit tests for `StatusAction.java` (#494)

### Updated

- Improve async progress status checking for some commands (#478)
- Make lint throw error with no config file (#483)

### Fixed

- Fixed regex to work correctly for Windows machines (#484)
