### PR TITLE
Add testReviewedOnly test

### DIFF
--- a/src/test/java/com/crowdin/cli/commands/actions/DownloadSourcesActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/DownloadSourcesActionTest.java
@@ -241,6 +241,10 @@ public class DownloadSourcesActionTest {
 
     @Test
     public void testDryRun() {
+        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        PrintStream ps = System.out;
+        System.setOut(new PrintStream(outContent));
+
         PropertiesWithFiles pb = NewPropertiesWithFilesUtilBuilder
             .minimalBuiltPropertiesBean(
                 "/values/strings.xml", "/values-%two_letters_code%/%original_file_name%",
@@ -262,7 +266,15 @@ public class DownloadSourcesActionTest {
         NewAction<PropertiesWithFiles, ProjectClient> action =
                 new DownloadSourcesAction(files, false, false, null, true, false,true);
         action.act(Outputter.getDefault(), pb, client);
-        
+
+        String outMessage1 = "✔️  Fetching project info\n";
+        String outMessage2 = "✔️  File @|bold 'common/strings.xml'|@\n";
+
+        client.downloadFullProject();
+        client.downloadFile(101L);
+
+        assertTrue(outContent.toString().contains(outMessage1));
+        assertTrue(outContent.toString().contains(outMessage2));
     }
 
     @Test

--- a/src/test/java/com/crowdin/cli/commands/actions/DownloadSourcesActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/DownloadSourcesActionTest.java
@@ -264,7 +264,7 @@ public class DownloadSourcesActionTest {
         FilesInterface files = mock(FilesInterface.class);
 
         NewAction<PropertiesWithFiles, ProjectClient> action =
-                new DownloadSourcesAction(files, false, false, null, true, false,true);
+            new DownloadSourcesAction(files, false, false, null, true, false,true);
         action.act(Outputter.getDefault(), pb, client);
 
         String outMessage1 = "✔️  Fetching project info\n";
@@ -284,25 +284,25 @@ public class DownloadSourcesActionTest {
         System.setOut(new PrintStream(outContent));
 
         PropertiesWithFiles pb = NewPropertiesWithFilesUtilBuilder
-                .minimalBuiltPropertiesBean(
-                        "/values/strings.xml", "/values-%two_letters_code%/%original_file_name%",
-                        null, "/common/%original_file_name%")
-                .setBasePath(project.getBasePath())
-                .build();
+            .minimalBuiltPropertiesBean(
+                "/values/strings.xml", "/values-%two_letters_code%/%original_file_name%",
+                null, "/common/%original_file_name%")
+            .setBasePath(project.getBasePath())
+            .build();
 
         ProjectClient client = mock(ProjectClient.class);
         when(client.downloadFullProject())
-                .thenReturn(ProjectBuilder.emptyProject(Long.parseLong(pb.getProjectId()))
-                        .addDirectory("common", 201L, null, null)
-                        .addFile("strings.xml", "gettext", 101L, 201L, null, "/values-%two_letters_code%/%original_file_name%").build());
+            .thenReturn(ProjectBuilder.emptyProject(Long.parseLong(pb.getProjectId()))
+                .addDirectory("common", 201L, null, null)
+                .addFile("strings.xml", "gettext", 101L, 201L, null, "/values-%two_letters_code%/%original_file_name%").build());
         URL urlMock = MockitoUtils.getMockUrl(getClass());
         when(client.downloadFile(eq(101L)))
-                .thenReturn(urlMock);
+            .thenReturn(urlMock);
 
         FilesInterface files = mock(FilesInterface.class);
 
         NewAction<PropertiesWithFiles, ProjectClient> action =
-                new DownloadSourcesAction(files, false, false, null, true, true, false);
+            new DownloadSourcesAction(files, false, false, null, true, true, false);
         action.act(Outputter.getDefault(), pb, client);
 
         String warnMessage = "⚠️  Operation is available only for Crowdin Enterprise\n";

--- a/src/test/java/com/crowdin/cli/commands/actions/DownloadSourcesActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/DownloadSourcesActionTest.java
@@ -1,6 +1,7 @@
 package com.crowdin.cli.commands.actions;
 
 import com.crowdin.cli.MockitoUtils;
+import com.crowdin.cli.client.CrowdinProject;
 import com.crowdin.cli.client.ProjectBuilder;
 import com.crowdin.cli.client.ProjectClient;
 import com.crowdin.cli.commands.NewAction;
@@ -13,17 +14,18 @@ import com.crowdin.cli.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.net.URL;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class DownloadSourcesActionTest {
 
@@ -265,32 +267,35 @@ public class DownloadSourcesActionTest {
 
     @Test
     public void testReviewedOnly() throws IOException {
+        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        PrintStream ps = System.out;
+        System.setOut(new PrintStream(outContent));
+
         PropertiesWithFiles pb = NewPropertiesWithFilesUtilBuilder
-            .minimalBuiltPropertiesBean(
-                    "/values/strings.xml", "/values-%two_letters_code%/%original_file_name%",
-                    null, "/common/%original_file_name%")
-            .setBasePath(project.getBasePath())
-            .build();
+                .minimalBuiltPropertiesBean(
+                        "/values/strings.xml", "/values-%two_letters_code%/%original_file_name%",
+                        null, "/common/%original_file_name%")
+                .setBasePath(project.getBasePath())
+                .build();
 
         ProjectClient client = mock(ProjectClient.class);
         when(client.downloadFullProject())
-            .thenReturn(ProjectBuilder.emptyProject(Long.parseLong(pb.getProjectId()))
-                    .addDirectory("common", 201L, null, null)
-                    .addFile("strings.xml", "gettext", 101L, 201L, null, "/values-%two_letters_code%/%original_file_name%").build());
-
+                .thenReturn(ProjectBuilder.emptyProject(Long.parseLong(pb.getProjectId()))
+                        .addDirectory("common", 201L, null, null)
+                        .addFile("strings.xml", "gettext", 101L, 201L, null, "/values-%two_letters_code%/%original_file_name%").build());
         URL urlMock = MockitoUtils.getMockUrl(getClass());
         when(client.downloadFile(eq(101L)))
-            .thenReturn(urlMock);
+                .thenReturn(urlMock);
 
         FilesInterface files = mock(FilesInterface.class);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = mock(DownloadSourcesAction.class);
-            new DownloadSourcesAction(files, false, false, null, true, true, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action =
+                new DownloadSourcesAction(files, false, false, null, true, true, false);
         action.act(Outputter.getDefault(), pb, client);
 
-        Mockito.doNothing().when(action).act(Outputter.getDefault(), pb, client);
+        String warnMessage = "⚠️  Operation is available only for Crowdin Enterprise\n";
 
-        Mockito.verifyNoInteractions(client);
-        Mockito.verifyNoInteractions(files);
+        client.downloadFullProject();
+        assertEquals(warnMessage, outContent.toString());
     }
 }


### PR DESCRIPTION
I know this test should be updated, but I would like to discuss below. 

- Although there are many lines added from `--reviewed` implementation, many functions in `DownloadSourceAction.java` are private functions. Only `act()` function is public. Please let me know if you have any expectation for private functions. 
- Maybe my lack of understanding. To me, I see a few branches to add tests in `act()` function. I can change `reviewedOnly`, `properties.getPreserveHierarchy()`. I would like to seek some advice how to approach to this test suite. 
- I haven't found a way to test console messages to test below code. `DownloadSourceAction.java` line 85 to 88. But I'm not sure if this is a good test plan. Let me know what you think. 

```java
if (!isOrganization && this.reviewedOnly) {
            out.println(WARNING.withIcon(RESOURCE_BUNDLE.getString("error.only_enterprise")));
            return;
        }
```
- Lastly, is there a way to check test coverage on my local? 

Sorry that it took so long to get here. But I would appreciate your advise. 