### PR TITLE
helper script for windows shell environments

### DIFF
--- a/scripts/crowdin
+++ b/scripts/crowdin
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+SCRIPT_DIR="$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
+exec java -jar "$SCRIPT_DIR/crowdin-cli.jar" $@


### PR DESCRIPTION
The following provides a helper script to invoke the `crowdin` CLI in a Windows shell environment (e.g. MinGW), without having to specify the `bat` extension.

---

The existing Crowdin CLI installation on Windows can run `crowdin` from a command line prompt as expected:

```
Microsoft Windows [Version 10.0.19045.2364]
(c) Microsoft Corporation. All rights reserved.

C:\Users\MyUser> crowdin --version
3.9.1
```

However, if a user starts a shell environment (e.g. MinGW from Git SCM tools), the environment will complain that the command cannot be found:

```
MyUser@MyUser-PC MINGW64 /
$ crowdin  --version
bash: crowdin: command not found
```

Users can workaround this by adding the `.bat` extension:

```
MyUser@MyUser-PC MINGW64 /
$ crowdin.bat --version
3.9.1
```

And if an environment includes the provided helper script in this pull request, it drops the requirement of needing to specify the extension:

```
MyUser@MyUser-PC MINGW64 /
$ crowdin --version
3.9.1
```