### PR TITLE
Version 3.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.9.2]
+
+### Added
+
+- Add the `--keep-archive` option for the download translations command ([#520](https://github.com/crowdin/crowdin-cli/pull/520))
+- Helper script for Windows shell environments ([#521](https://github.com/crowdin/crowdin-cli/pull/521))
+
+### Updated
+
+- More tests for better coverage ([#509](https://github.com/crowdin/crowdin-cli/pull/509))
+- Minor cleanup ([#511](https://github.com/crowdin/crowdin-cli/pull/511))
+- Use GH Actions instead of Azure Pipelines and prepare CI to run Unit tests on Windows ([#512](https://github.com/crowdin/crowdin-cli/pull/512))
+- Ignore version check for -h,-v and crowdin command w/o args ([#516](https://github.com/crowdin/crowdin-cli/pull/516))
+- Handle empty files upload ([#517](https://github.com/crowdin/crowdin-cli/pull/517))
+
+### Fixed
+
+- Fix node-fetch issue ([#524](https://github.com/crowdin/crowdin-cli/pull/524))
+
 ## [3.9.1]
 
 ### Updated

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 apply plugin: 'checkstyle'
 
 group 'com.crowdin'
-version '3.9.1'
+version '3.9.2'
 
 sourceCompatibility = 1.8
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowdin/cli",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/crowdin/crowdin-cli.git"
   },
-  "version": "3.9.1",
+  "version": "3.9.2",
   "jdeploy": {
     "jar": "dist/crowdin-cli.jar"
   },

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Senya <senya at riseup.net>
 pkgname=crowdin-cli
-pkgver=3.9.1
+pkgver=3.9.2
 pkgrel=1
 pkgdesc="Command line tool that allows you to manage and synchronize localization resources with your Crowdin project"
 url="https://support.crowdin.com/cli-tool/"

--- a/src/main/resources/crowdin.properties
+++ b/src/main/resources/crowdin.properties
@@ -1,5 +1,5 @@
 application.name=crowdin-cli
-application.version=3.9.1
+application.version=3.9.2
 application.base_url=https://api.crowdin.com
 application.user_agent=crowdin-java-cli
 application.version_file_url=https://downloads.crowdin.com/cli/v3/version.txt


### PR DESCRIPTION
### Added

- Add the `--keep-archive` option for the download translations command in #520 by @yzerk  
- Helper script for Windows shell environments in #521 by @jdknight

### Updated

- More tests for better coverage in #509 by @calfaand
- Minor cleanup in #511 by @andrii-bodnar 
- Use GH Actions instead of Azure Pipelines and prepare CI to run Unit tests on Windows in #512 by @andrii-bodnar 
- Ignore version check for `-h`, `-v` and `crowdin` command w/o args in #516 by @yzerk 
- Handle empty files upload in #517 by @yzerk 

### Fixed

- Fix node-fetch issue in #524 by @andrii-bodnar 
