### PR TITLE
ci: fix chocolatey shasum update

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -20,16 +20,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Download the latest zip
-        uses: carlosperate/download-file-action@v2
-        with:
-          file-url: 'https://downloads.crowdin.com/cli/v3/crowdin-cli.zip'
-
-      - name: Generate shasum
-        id: shasum
-        run: echo hash=$(shasum -a 256 crowdin-cli.zip | cut -f 1 -d " ") >> $GITHUB_OUTPUT
-
       - name: Bump version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release --define CHECKSUM=${{ steps.shasum.outputs.hash }}
+        run: |
+          npx semantic-release
+          npx semantic-release --version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,33 @@ on:
     types: [released]
 
 jobs:
+  assets:
+    runs-on: ubuntu-latest
+    outputs:
+      checksum: ${{ steps.shasum.outputs.hash }}
+    steps:
+      - name: Download the latest zip
+        uses: carlosperate/download-file-action@v2
+        with:
+          file-url: 'https://downloads.crowdin.com/cli/v3/crowdin-cli.zip'
+
+      - name: Generate shasum
+        id: shasum
+        run: |
+          echo hash=$(shasum -a 256 crowdin-cli.zip | cut -f 1 -d " ") >> $GITHUB_OUTPUT
+          touch crowdin-cli_checksum.sha256
+          shasum -a 256 crowdin-cli.zip > crowdin-cli_checksum.sha256
+
+      - name: Upload asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            crowdin-cli.zip
+            crowdin-cli_checksum.sha256
+
   npm:
     runs-on: ubuntu-latest
+    needs: assets
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v1
@@ -30,6 +55,7 @@ jobs:
 
   aur:
     runs-on: ubuntu-latest
+    needs: assets
     steps:
       - uses: actions/checkout@v3
       - name: Publish AUR package
@@ -45,6 +71,7 @@ jobs:
 
   homebrew:
     runs-on: ubuntu-latest
+    needs: assets
     steps:
       - name: Invoke workflow in the homebrew-crowdin repo
         uses: benc-uk/workflow-dispatch@v1
@@ -56,8 +83,16 @@ jobs:
 
   chocolatey:
     runs-on: windows-latest
+    needs: assets
     steps:
       - uses: actions/checkout@v3
+
+      - name: Update checksum
+        run: |
+          echo "New Hash: ${{ needs.assets.outputs.checksum }}\n"
+          sed -i "s/checksum      = '.*'/checksum      = '${{ needs.assets.outputs.checksum }}'/g" chocolatey/tools/chocolateyinstall.ps1
+          cat chocolatey/tools/chocolateyinstall.ps1
+
       - name: Choco pack
         uses: crazy-max/ghaction-chocolatey@v2
         with:
@@ -67,16 +102,3 @@ jobs:
         uses: crazy-max/ghaction-chocolatey@v2
         with:
           args: push chocolatey/crowdin-cli.nuspec --api-key ${{ secrets.CHOCOLATEY_API_KEY }}
-
-  release-asset:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download asset
-        uses: carlosperate/download-file-action@v2
-        with:
-          file-url: 'https://downloads.crowdin.com/cli/v3/crowdin-cli.zip'
-
-      - name: Upload asset
-        uses: softprops/action-gh-release@v1
-        with:
-          files: 'crowdin-cli.zip'

--- a/release.config.js
+++ b/release.config.js
@@ -97,22 +97,6 @@ module.exports = {
               }
             ],
             "countMatches": true
-          },
-          {
-            "files": [
-              "chocolatey/tools/chocolateyinstall.ps1"
-            ],
-            "from": "checksum      = '.*'",
-            "to": "checksum      = '" + process.env.CHECKSUM +  "'",
-            "results": [
-              {
-                "file": "chocolatey/tools/chocolateyinstall.ps1",
-                "hasChanged": true,
-                "numMatches": 1,
-                "numReplacements": 1
-              }
-            ],
-            "countMatches": true
           }
         ]
       }


### PR DESCRIPTION
The current WF is wrong since at the version bumping state we still have an old CLI under the download link, so we can't update the shasum for the package. Decided to do it during the publishing stage. The committed version will be always outdated but updated locally during the publishing stage.