### PR TITLE
fix(config): discrepancies and indentation

### DIFF
--- a/src/main/resources/crowdin.yml
+++ b/src/main/resources/crowdin.yml
@@ -1,10 +1,10 @@
 #
 # Your Crowdin credentials
 #
-"project_id" : ""
-"api_token" : ""
-"base_path" : ""
-"base_url" : ""
+"project_id": ""
+"api_token": ""
+"base_path": ""
+"base_url": ""
 
 #
 # Choose file structure in Crowdin
@@ -16,112 +16,112 @@
 # Files configuration
 #
 files: [
- {
-  #
-  # Source files filter
-  # e.g. "/resources/en/*.json"
-  #
-  "source" : "",
+  {
+    #
+    # Source files filter
+    # e.g. "/resources/en/*.json"
+    #
+    "source": "",
 
-  #
-  # Where translations will be placed
-  # e.g. "/resources/%two_letters_code%/%original_file_name%"
-  #
-  "translation" : "",
+    #
+    # Where translations will be placed
+    # e.g. "/resources/%two_letters_code%/%original_file_name%"
+    #
+    "translation": "",
 
-  #
-  # Files or directories for ignore
-  # e.g. ["/**/?.txt", "/**/[0-9].txt", "/**/*\?*.txt"]
-  #
-  #"ignore" : [],
+    #
+    # Files or directories for ignore
+    # e.g. ["/**/?.txt", "/**/[0-9].txt", "/**/*\?*.txt"]
+    #
+    # "ignore": [],
 
-  #
-  # The dest allows you to specify a file name in Crowdin
-  # e.g. "/messages.json"
-  #
-  #"dest" : "",
+    #
+    # The dest allows you to specify a file name in Crowdin
+    # e.g. "/messages.json"
+    #
+    # "dest": "",
 
-  #
-  # File type
-  # e.g. "json"
-  #
-  #"type" : "",
+    #
+    # File type
+    # e.g. "json"
+    #
+    # "type": "",
 
-  #
-  # The parameter "update_option" is optional. If it is not set, after the files update the translations for changed strings will be removed. Use to fix typos and for minor changes in the source strings
-  # e.g. "update_as_unapproved" or "update_without_changes"
-  #
-  #"update_option" : "",
+    #
+    # The parameter "update_option" is optional. If it is not set, after the files update the translations for changed strings will be removed. Use to fix typos and for minor changes in the source strings
+    # e.g. "update_as_unapproved" or "update_without_changes"
+    #
+    # "update_option": "",
 
-  #
-  # Start block (for XML only)
-  #
+    #
+    # Start block (for XML only)
+    #
 
-  #
-  # Defines whether to translate tags attributes.
-  # e.g. 0 or 1  (Default is 1)
-  #
-  # "translate_attributes" : 1,
+    #
+    # Defines whether to translate tags attributes.
+    # e.g. 0 or 1  (Default is 1)
+    #
+    # "translate_attributes": 1,
 
-  #
-  # Defines whether to translate texts placed inside the tags.
-  # e.g. 0 or 1 (Default is 1)
-  #
-  # "translate_content" : 1,
+    #
+    # Defines whether to translate texts placed inside the tags.
+    # e.g. 0 or 1 (Default is 1)
+    #
+    # "translate_content": 1,
 
-  #
-  # This is an array of strings, where each item is the XPaths to DOM element that should be imported
-  # e.g. ["/content/text", "/content/text[@value]"]
-  #
-  # "translatable_elements" : [],
+    #
+    # This is an array of strings, where each item is the XPaths to DOM element that should be imported
+    # e.g. ["/content/text", "/content/text[@value]"]
+    #
+    # "translatable_elements": [],
 
-  #
-  # Defines whether to split long texts into smaller text segments
-  # e.g. 0 or 1 (Default is 1)
-  #
-  # "content_segmentation" : 1,
+    #
+    # Defines whether to split long texts into smaller text segments
+    # e.g. 0 or 1 (Default is 1)
+    #
+    # "content_segmentation": 1,
 
-  #
-  # End block (for XML only)
-  #
+    #
+    # End block (for XML only)
+    #
 
-  #
-  # Start .properties block
-  #
+    #
+    # Start .properties block
+    #
 
-  #
-  # Defines whether single quote should be escaped by another single quote or backslash in exported translations
-  # e.g. 0 or 1 or 2 or 3 (Default is 3)
-  # 0 - do not escape single quote;
-  # 1 - escape single quote by another single quote;
-  # 2 - escape single quote by backslash;
-  # 3 - escape single quote by another single quote only in strings containing variables ( {0} ).
-  #
-  # "escape_quotes" : 3,
+    #
+    # Defines whether single quote should be escaped by another single quote or backslash in exported translations
+    # e.g. 0 or 1 or 2 or 3 (Default is 3)
+    # 0 - do not escape single quote;
+    # 1 - escape single quote by another single quote;
+    # 2 - escape single quote by backslash;
+    # 3 - escape single quote by another single quote only in strings containing variables ( {0} ).
+    #
+    # "escape_quotes": 3,
 
-  #
-  # Defines whether any special characters (=, :, ! and #) should be escaped by backslash in exported translations.
-  # e.g. 0 or 1 (Default is 0)
-  # 0 - do not escape special characters
-  # 1 - escape special characters by a backslash
-  #
-  # "escape_special_characters": 0
-  #
+    #
+    # Defines whether any special characters (=, :, ! and #) should be escaped by backslash in exported translations.
+    # e.g. 0 or 1 (Default is 0)
+    # 0 - do not escape special characters
+    # 1 - escape special characters by a backslash
+    #
+    # "escape_special_characters": 0
+    #
 
-  #
-  # End .properties block
-  #
+    #
+    # End .properties block
+    #
 
-  #
-  # Does the first line contain header?
-  # e.g. true or false
-  #
-  #"first_line_contains_header" : true,
+    #
+    # Does the first line contain header?
+    # e.g. true or false
+    #
+    # "first_line_contains_header": true,
 
-  #
-  # for spreadsheets
-  # e.g. "identifier,source_phrase,context,uk,ru,fr"
-  #
-  # "scheme" : "",
- }
+    #
+    # for spreadsheets
+    # e.g. "identifier,source_phrase,context,uk,ru,fr"
+    #
+    # "scheme": "",
+  }
 ]


### PR DESCRIPTION
Hi,

Currently, when you call `crowdin init` and following the process, you get a crowdin.yml file with some pre-filled data. By default, indentations come as single space, and commented sections are not matching with each other in terms of format. Some have a space after `#` some don't, some has a space after `:` and some don't. 

This PR is to streamline the formatting in the file and to solve the indentation and discrepancy problems. It's one of the very first files people interact with after initialising their projects, it'd be a better experience if it looks more welcoming. 

I hope this makes sense. Thanks in advance for your consideration.

Best,
G.