### PR TITLE
revert: square brackets fix

### DIFF
--- a/src/main/java/com/crowdin/cli/properties/helper/FileMatcher.java
+++ b/src/main/java/com/crowdin/cli/properties/helper/FileMatcher.java
@@ -28,9 +28,6 @@ class FileMatcher implements PathMatcher {
         pattern = pattern.replaceAll("/+", "/");
         pattern = pattern.replaceAll("\\{\\{+", "\\\\{\\\\{");
         pattern = pattern.replaceAll("}}+", "\\\\}\\\\}");
-        pattern = pattern.replaceAll("\\[+", "\\\\[");
-        pattern = pattern.replaceAll("]+", "\\\\]");
-
 
         // We *could* implement exactly what's documented. The idea would be to implement something like
         // Java's Globs.toRegexPattern but supporting only the documented syntax. Instead, we will use

--- a/src/test/java/com/crowdin/cli/properties/helper/FileHelperTest.java
+++ b/src/test/java/com/crowdin/cli/properties/helper/FileHelperTest.java
@@ -84,7 +84,6 @@ public class FileHelperTest {
         sources.add(new File("/files/folder/sub/1.xml"));
         sources.add(new File("/files/{{cookiecutter.module_name}}"));
         sources.add(new File("/files/{{cookiecutter.module_name}}/1.xml"));
-        sources.add(new File("/files/[folder-sub]/1.xml"));
         FileHelper fileHelper = new FileHelper(project.getBasePath());
         List<File> actualResult = fileHelper.filterOutIgnoredFiles(sources, Arrays.asList(".*"));
         assertEquals(sources, actualResult);


### PR DESCRIPTION
The #645 breaks the range configuration for the `source` and `ignore` patterns, e.g. `/**/[0-9].txt`.

Will be investigated in more detail

https://developer.crowdin.com/configuration-file/