### PR TITLE
feat: delete screenshot by id

### DIFF
--- a/src/main/java/com/crowdin/cli/commands/Actions.java
+++ b/src/main/java/com/crowdin/cli/commands/Actions.java
@@ -126,7 +126,7 @@ public interface Actions {
 
     NewAction<ProjectProperties, ClientScreenshot> screenshotUpload(File file, String branchName, List<String> labelNames, String directoryPath, String filePath, boolean autoTag, boolean plainView, boolean noProgress, ProjectClient projectClient);
 
-    NewAction<ProjectProperties, ClientScreenshot> screenshotDelete(String name);
+    NewAction<ProjectProperties, ClientScreenshot> screenshotDelete(Long id);
 
     NewAction<ProjectProperties, ClientLabel> labelList(boolean plainView, boolean isVerbose);
 

--- a/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
@@ -259,8 +259,8 @@ public class CliActions implements Actions {
     }
 
     @Override
-    public NewAction<ProjectProperties, ClientScreenshot> screenshotDelete(String name) {
-        return new ScreenshotDeleteAction(name);
+    public NewAction<ProjectProperties, ClientScreenshot> screenshotDelete(Long id) {
+        return new ScreenshotDeleteAction(id);
     }
 
     @Override

--- a/src/main/java/com/crowdin/cli/commands/actions/ScreenshotDeleteAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/ScreenshotDeleteAction.java
@@ -5,29 +5,20 @@ import com.crowdin.cli.commands.NewAction;
 import com.crowdin.cli.commands.Outputter;
 import com.crowdin.cli.properties.ProjectProperties;
 import com.crowdin.cli.utils.console.ExecutionStatus;
-import com.crowdin.client.screenshots.model.Screenshot;
-
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static com.crowdin.cli.BaseCli.RESOURCE_BUNDLE;
 
 class ScreenshotDeleteAction implements NewAction<ProjectProperties, ClientScreenshot> {
 
-    private final String name;
+    private final Long id;
 
-    public ScreenshotDeleteAction(String name) {
-        this.name = name;
+    public ScreenshotDeleteAction(Long id) {
+        this.id = id;
     }
 
     @Override
     public void act(Outputter out, ProjectProperties properties, ClientScreenshot client) {
-        Map<String, Long> screenshots = client.listScreenshots(null).stream()
-            .collect(Collectors.toMap(Screenshot::getName, Screenshot::getId));
-        if (!screenshots.containsKey(name)) {
-            throw new RuntimeException(String.format(RESOURCE_BUNDLE.getString("error.screenshot.not_found"), name));
-        }
-        client.deleteScreenshot(screenshots.get(name));
-        out.println(ExecutionStatus.OK.withIcon(String.format(RESOURCE_BUNDLE.getString("message.screenshot.deleted"), name)));
+        client.deleteScreenshot(id);
+        out.println(ExecutionStatus.OK.withIcon(String.format(RESOURCE_BUNDLE.getString("message.screenshot.deleted"), id)));
     }
 }

--- a/src/main/java/com/crowdin/cli/commands/picocli/ScreenshotDeleteSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/ScreenshotDeleteSubcommand.java
@@ -11,11 +11,11 @@ import picocli.CommandLine;
 )
 class ScreenshotDeleteSubcommand extends ActCommandScreenshot {
 
-    @CommandLine.Parameters(descriptionKey = "crowdin.screenshot.delete.name")
-    protected String name;
+    @CommandLine.Parameters(descriptionKey = "crowdin.screenshot.delete.id")
+    protected Long id;
 
     @Override
     protected NewAction<ProjectProperties, ClientScreenshot> getAction(Actions actions) {
-        return actions.screenshotDelete(name);
+        return actions.screenshotDelete(id);
     }
 }

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -397,7 +397,7 @@ crowdin.screenshot.list.string-id=Numeric string identifier
 # CROWDIN SCREENSHOT DELETE
 crowdin.screenshot.delete.usage.description=Delete screenshot
 crowdin.screenshot.delete.usage.customSynopsis=@|fg(green) crowdin screenshot delete|@ <name> [CONFIG OPTIONS] [OPTIONS]
-crowdin.screenshot.delete.name=Screenshot name
+crowdin.screenshot.delete.id=Screenshot id
 
 # CROWDIN SCREENSHOT UPLOAD
 crowdin.screenshot.upload.usage.description=Add screenshot
@@ -566,7 +566,6 @@ error.screenshot.auto-tag_required_for_file='--auto-tag' is required for '--file
 error.screenshot.auto-tag_required_for_branch='--auto-tag' is required for '--branch' option
 error.screenshot.auto-tag_required_for_directory='--auto-tag' is required for '--directory' option
 error.screenshot.only_one_allowed=Only one of the following options can be used at a time: '--file', '--branch' or '--directory'
-error.screenshot.not_found=Screenshot %s not found in the Crowdin project
 error.screenshot.not_uploaded=Screenshot was not uploaded
 error.screenshot.not_updated=Screenshot was not updated
 

--- a/src/test/java/com/crowdin/cli/commands/actions/ScreenshotDeleteActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/ScreenshotDeleteActionTest.java
@@ -7,83 +7,54 @@ import com.crowdin.cli.properties.NewPropertiesWithFilesUtilBuilder;
 import com.crowdin.cli.properties.ProjectProperties;
 import com.crowdin.cli.properties.PropertiesWithFiles;
 import com.crowdin.cli.utils.Utils;
-import com.crowdin.client.screenshots.model.Screenshot;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.*;
 
 public class ScreenshotDeleteActionTest {
 
     private static final Long SCREENSHOT_ID = 12L;
-    private static final String SCREENSHOT_NAME = "screenshot.jpg";
-
     private NewAction<ProjectProperties, ClientScreenshot> action;
 
-    @ParameterizedTest
-    @MethodSource
-    public void testScreenshotDelete(List<Screenshot> screenshots) {
+    @Test
+    public void testScreenshotDelete() {
         NewPropertiesWithFilesUtilBuilder pbBuilder = NewPropertiesWithFilesUtilBuilder
-            .minimalBuiltPropertiesBean("*", Utils.PATH_SEPARATOR + "%original_file_name%-CR-%locale%")
-            .setBasePath(Utils.PATH_SEPARATOR);
+                .minimalBuiltPropertiesBean("*", Utils.PATH_SEPARATOR + "%original_file_name%-CR-%locale%")
+                .setBasePath(Utils.PATH_SEPARATOR);
         PropertiesWithFiles pb = pbBuilder.build();
 
         ClientScreenshot client = mock(ClientScreenshot.class);
 
-        when(client.listScreenshots(null))
-            .thenReturn(screenshots);
         doNothing().when(client).deleteScreenshot(SCREENSHOT_ID);
 
-        action = new ScreenshotDeleteAction(SCREENSHOT_NAME);
+        action = new ScreenshotDeleteAction(SCREENSHOT_ID);
         action.act(Outputter.getDefault(), pb, client);
 
-        verify(client).listScreenshots(null);
         verify(client).deleteScreenshot(SCREENSHOT_ID);
         verifyNoMoreInteractions(client);
-    }
-
-    public static Stream<Arguments> testScreenshotDelete() {
-        return Stream.of(
-            arguments(Arrays.asList(
-                new Screenshot() {{
-                    setName("screenshot1.gif");
-                    setId(6L);
-                }},
-                new Screenshot() {{
-                    setName(SCREENSHOT_NAME);
-                    setId(SCREENSHOT_ID);
-                }}
-            ))
-        );
     }
 
     @Test
     public void testScreenshotDelete_throwsNotFound() {
         NewPropertiesWithFilesUtilBuilder pbBuilder = NewPropertiesWithFilesUtilBuilder
-            .minimalBuiltPropertiesBean("*", Utils.PATH_SEPARATOR + "%original_file_name%-CR-%locale%")
-            .setBasePath(Utils.PATH_SEPARATOR);
+                .minimalBuiltPropertiesBean("*", Utils.PATH_SEPARATOR + "%original_file_name%-CR-%locale%")
+                .setBasePath(Utils.PATH_SEPARATOR);
         PropertiesWithFiles pb = pbBuilder.build();
 
         ClientScreenshot client = mock(ClientScreenshot.class);
 
         when(client.listScreenshots(null))
-            .thenReturn(new ArrayList<>());
-        doNothing().when(client).deleteScreenshot(SCREENSHOT_ID);
+                .thenReturn(new ArrayList<>());
+        doThrow(new RuntimeException("Not found")).when(client).deleteScreenshot(SCREENSHOT_ID);
 
-        action = new ScreenshotDeleteAction("not_existing.png");
+        action = new ScreenshotDeleteAction(SCREENSHOT_ID);
 
         assertThrows(RuntimeException.class, () -> action.act(Outputter.getDefault(), pb, client));
 
-        verify(client).listScreenshots(null);
+        verify(client).deleteScreenshot(SCREENSHOT_ID);
         verifyNoMoreInteractions(client);
     }
 }

--- a/src/test/java/com/crowdin/cli/commands/picocli/ScreenshotDeleteSubcommandTest.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/ScreenshotDeleteSubcommandTest.java
@@ -9,7 +9,7 @@ public class ScreenshotDeleteSubcommandTest extends PicocliTestUtils {
 
     @Test
     public void testScreenshotDelete() {
-        this.execute(CommandNames.SCREENSHOT, CommandNames.SCREENSHOT_DELETE, "screenshot.png");
+        this.execute(CommandNames.SCREENSHOT, CommandNames.SCREENSHOT_DELETE, "123");
         verify(actionsMock).screenshotDelete(any());
         this.check(true);
     }


### PR DESCRIPTION
Replaced `name` parameter with `id` to delete screenshot

Before:

- `crowdin screenshot delete <name>`

After:

(Use `list` command to get id)

- `crowdin screenshot delete <id>`