### PR TITLE
feat: glossary & tm updates

### DIFF
--- a/src/main/java/com/crowdin/cli/client/ClientGlossary.java
+++ b/src/main/java/com/crowdin/cli/client/ClientGlossary.java
@@ -17,7 +17,7 @@ public interface ClientGlossary extends Client {
 
     List<Glossary> listGlossaries();
 
-    Optional<Glossary> getGlossary(Long glossaryId);
+    Glossary getGlossary(Long glossaryId);
 
     Glossary addGlossary(AddGlossaryRequest request);
 

--- a/src/main/java/com/crowdin/cli/client/ClientTm.java
+++ b/src/main/java/com/crowdin/cli/client/ClientTm.java
@@ -16,7 +16,7 @@ public interface ClientTm extends Client {
 
     List<TranslationMemory> listTms();
 
-    Optional<TranslationMemory> getTm(Long tmId);
+    TranslationMemory getTm(Long tmId);
 
     TranslationMemory addTm(AddTranslationMemoryRequest request);
 

--- a/src/main/java/com/crowdin/cli/client/CrowdinClientGlossary.java
+++ b/src/main/java/com/crowdin/cli/client/CrowdinClientGlossary.java
@@ -14,7 +14,6 @@ import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.BiPredicate;
 
 public class CrowdinClientGlossary extends CrowdinClientCore implements ClientGlossary {
@@ -32,14 +31,10 @@ public class CrowdinClientGlossary extends CrowdinClientCore implements ClientGl
     }
 
     @Override
-    public Optional<Glossary> getGlossary(Long glossaryId) {
-        try {
-            return Optional.of(executeRequest(() -> this.client.getGlossariesApi()
+    public Glossary getGlossary(Long glossaryId) {
+        return executeRequest(() -> this.client.getGlossariesApi()
                 .getGlossary(glossaryId)
-                .getData()));
-        } catch (Exception e) {
-            return Optional.empty();
-        }
+                .getData());
     }
 
     @Override

--- a/src/main/java/com/crowdin/cli/client/CrowdinClientTm.java
+++ b/src/main/java/com/crowdin/cli/client/CrowdinClientTm.java
@@ -11,7 +11,6 @@ import com.crowdin.client.translationmemory.model.TranslationMemoryImportStatus;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
-import java.util.Optional;
 
 public class CrowdinClientTm extends CrowdinClientCore implements ClientTm {
 
@@ -28,14 +27,10 @@ public class CrowdinClientTm extends CrowdinClientCore implements ClientTm {
     }
 
     @Override
-    public Optional<TranslationMemory> getTm(Long tmId) {
-        try {
-            return Optional.of(executeRequest(() -> this.client.getTranslationMemoryApi()
+    public TranslationMemory getTm(Long tmId) {
+        return executeRequest(() -> this.client.getTranslationMemoryApi()
                 .getTm(tmId)
-                .getData()));
-        } catch (Exception e) {
-            return Optional.empty();
-        }
+                .getData());
     }
 
     @Override

--- a/src/main/java/com/crowdin/cli/commands/Actions.java
+++ b/src/main/java/com/crowdin/cli/commands/Actions.java
@@ -73,7 +73,7 @@ public interface Actions {
     NewAction<BaseProperties, ClientGlossary> glossaryList(boolean plainView, boolean isVerbose);
 
     NewAction<BaseProperties, ClientGlossary> glossaryUpload(
-        java.io.File file, Long id, String name, String languageId, Map<String, Integer> scheme, Boolean firstLineContainsHeader);
+        java.io.File file, Long id, String languageId, Map<String, Integer> scheme, Boolean firstLineContainsHeader);
 
     NewAction<BaseProperties, ClientGlossary> glossaryDownload(
         Long id, GlossariesFormat format, boolean noProgress, File to, FilesInterface files);

--- a/src/main/java/com/crowdin/cli/commands/Actions.java
+++ b/src/main/java/com/crowdin/cli/commands/Actions.java
@@ -76,7 +76,7 @@ public interface Actions {
         java.io.File file, Long id, String name, String languageId, Map<String, Integer> scheme, Boolean firstLineContainsHeader);
 
     NewAction<BaseProperties, ClientGlossary> glossaryDownload(
-        Long id, String name, GlossariesFormat format, boolean noProgress, File to, FilesInterface files);
+        Long id, GlossariesFormat format, boolean noProgress, File to, FilesInterface files);
 
     NewAction<BaseProperties, ClientTm> tmList(boolean plainView);
 

--- a/src/main/java/com/crowdin/cli/commands/Actions.java
+++ b/src/main/java/com/crowdin/cli/commands/Actions.java
@@ -84,7 +84,7 @@ public interface Actions {
         File file, Long id, String name, String languageId, Map<String, Integer> scheme, Boolean firstLineContainsHeader);
 
     NewAction<BaseProperties, ClientTm> tmDownload(
-        Long id, String name, TranslationMemoryFormat format, String sourceLanguageId,
+        Long id, TranslationMemoryFormat format, String sourceLanguageId,
         String targetLanguageId, boolean noProgress, File to, FilesInterface files);
 
     NewAction<ProjectProperties, ClientTask> taskList(boolean plainView, boolean isVerbose, String status, Long assigneeId);

--- a/src/main/java/com/crowdin/cli/commands/Actions.java
+++ b/src/main/java/com/crowdin/cli/commands/Actions.java
@@ -81,7 +81,7 @@ public interface Actions {
     NewAction<BaseProperties, ClientTm> tmList(boolean plainView);
 
     NewAction<BaseProperties, ClientTm> tmUpload(
-        File file, Long id, String name, String languageId, Map<String, Integer> scheme, Boolean firstLineContainsHeader);
+        File file, Long id, String languageId, Map<String, Integer> scheme, Boolean firstLineContainsHeader);
 
     NewAction<BaseProperties, ClientTm> tmDownload(
         Long id, TranslationMemoryFormat format, String sourceLanguageId,

--- a/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
@@ -160,10 +160,10 @@ public class CliActions implements Actions {
 
     @Override
     public NewAction<BaseProperties, ClientTm> tmDownload(
-        Long id, String name, TranslationMemoryFormat format, String sourceLanguageId,
+        Long id, TranslationMemoryFormat format, String sourceLanguageId,
         String targetLanguageId, boolean noProgress, File to, FilesInterface files
     ) {
-        return new TmDownloadAction(id, name, format, sourceLanguageId, targetLanguageId, noProgress, to, files);
+        return new TmDownloadAction(id, format, sourceLanguageId, targetLanguageId, noProgress, to, files);
     }
 
     @Override

--- a/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
@@ -141,9 +141,9 @@ public class CliActions implements Actions {
 
     @Override
     public NewAction<BaseProperties, ClientGlossary> glossaryDownload(
-        Long id, String name, GlossariesFormat format, boolean noProgress, File to, FilesInterface files
+        Long id, GlossariesFormat format, boolean noProgress, File to, FilesInterface files
     ) {
-        return new GlossaryDownloadAction(id, name, format, noProgress, to, files);
+        return new GlossaryDownloadAction(id, format, noProgress, to, files);
     }
 
     @Override

--- a/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
@@ -134,9 +134,9 @@ public class CliActions implements Actions {
 
     @Override
     public NewAction<BaseProperties, ClientGlossary> glossaryUpload(
-        java.io.File file, Long id, String name, String languageId, Map<String, Integer> scheme, Boolean firstLineContainsHeader
+        java.io.File file, Long id, String languageId, Map<String, Integer> scheme, Boolean firstLineContainsHeader
     ) {
-        return new GlossaryUploadAction(file, id, name, languageId, scheme, firstLineContainsHeader);
+        return new GlossaryUploadAction(file, id, languageId, scheme, firstLineContainsHeader);
     }
 
     @Override

--- a/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
@@ -153,9 +153,9 @@ public class CliActions implements Actions {
 
     @Override
     public NewAction<BaseProperties, ClientTm> tmUpload(
-        File file, Long id, String name, String languageId, Map<String, Integer> scheme, Boolean firstLineContainsHeader
+        File file, Long id, String languageId, Map<String, Integer> scheme, Boolean firstLineContainsHeader
     ) {
-        return new TmUploadAction(file, id, name, languageId, scheme, firstLineContainsHeader);
+        return new TmUploadAction(file, id, languageId, scheme, firstLineContainsHeader);
     }
 
     @Override

--- a/src/main/java/com/crowdin/cli/commands/actions/GlossaryDownloadAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/GlossaryDownloadAction.java
@@ -24,15 +24,13 @@ import static com.crowdin.cli.BaseCli.RESOURCE_BUNDLE;
 class GlossaryDownloadAction implements NewAction<BaseProperties, ClientGlossary> {
 
     private final Long id;
-    private final String name;
     private final GlossariesFormat format;
     private final boolean noProgress;
     private File to;
     private final FilesInterface files;
 
-    public GlossaryDownloadAction(Long id, String name, GlossariesFormat format, boolean noProgress, File to, FilesInterface files) {
+    public GlossaryDownloadAction(Long id, GlossariesFormat format, boolean noProgress, File to, FilesInterface files) {
         this.id = id;
-        this.name = name;
         this.format = format;
         this.noProgress = noProgress;
         this.to = to;
@@ -51,23 +49,8 @@ class GlossaryDownloadAction implements NewAction<BaseProperties, ClientGlossary
     }
 
     private Glossary getGlossary(ClientGlossary client) {
-        if (id != null) {
-            return client.getGlossary(id)
+        return client.getGlossary(id)
                 .orElseThrow(() -> new RuntimeException(RESOURCE_BUNDLE.getString("error.glossary.not_found_by_id")));
-        } else if (name != null) {
-            List<Glossary> foundGlossaries = client.listGlossaries().stream()
-                .filter(gl -> gl.getName() != null && gl.getName().equals(name))
-                .collect(Collectors.toList());
-            if (foundGlossaries.isEmpty()) {
-                throw new RuntimeException(RESOURCE_BUNDLE.getString("error.glossary.not_found_by_name"));
-            } else if (foundGlossaries.size() == 1) {
-                return foundGlossaries.get(0);
-            } else {
-                throw new RuntimeException(RESOURCE_BUNDLE.getString("error.glossary.more_than_one_glossary_by_that_name"));
-            }
-        } else {
-            throw new RuntimeException(RESOURCE_BUNDLE.getString("error.glossary.no_identifiers"));
-        }
     }
 
     private GlossaryExportStatus buildGlossary(Outputter out, ClientGlossary client, Long glossaryId, ExportGlossaryRequest request) {

--- a/src/main/java/com/crowdin/cli/commands/actions/GlossaryDownloadAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/GlossaryDownloadAction.java
@@ -16,8 +16,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.crowdin.cli.BaseCli.RESOURCE_BUNDLE;
 
@@ -49,8 +47,7 @@ class GlossaryDownloadAction implements NewAction<BaseProperties, ClientGlossary
     }
 
     private Glossary getGlossary(ClientGlossary client) {
-        return client.getGlossary(id)
-                .orElseThrow(() -> new RuntimeException(RESOURCE_BUNDLE.getString("error.glossary.not_found_by_id")));
+        return client.getGlossary(id);
     }
 
     private GlossaryExportStatus buildGlossary(Outputter out, ClientGlossary client, Long glossaryId, ExportGlossaryRequest request) {

--- a/src/main/java/com/crowdin/cli/commands/actions/GlossaryListAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/GlossaryListAction.java
@@ -29,7 +29,7 @@ class GlossaryListAction implements NewAction<BaseProperties, ClientGlossary> {
         for (Glossary glossary : glossaries) {
             if (!plainView) {
                 out.println(OK.withIcon(
-                    String.format(RESOURCE_BUNDLE.getString("message.glossary.list"), glossary.getName(), glossary.getId(), glossary.getTerms())));
+                    String.format(RESOURCE_BUNDLE.getString("message.glossary.list"), glossary.getId(), glossary.getName(), glossary.getTerms())));
                 if (isVerbose && mayHaveTerms(glossary)) {
                     try {
                         List<Term> terms = client.listTerms(glossary.getId());

--- a/src/main/java/com/crowdin/cli/commands/actions/GlossaryListAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/GlossaryListAction.java
@@ -10,6 +10,7 @@ import com.crowdin.client.glossaries.model.Term;
 import java.util.List;
 
 import static com.crowdin.cli.BaseCli.RESOURCE_BUNDLE;
+import static com.crowdin.cli.utils.Utils.toSingleLineString;
 import static com.crowdin.cli.utils.console.ExecutionStatus.OK;
 import static com.crowdin.cli.utils.console.ExecutionStatus.WARNING;
 
@@ -34,7 +35,7 @@ class GlossaryListAction implements NewAction<BaseProperties, ClientGlossary> {
                     try {
                         List<Term> terms = client.listTerms(glossary.getId());
                         for (Term term : terms) {
-                            String description = (term.getDescription() != null) ? term.getDescription() : "";
+                            String description = toSingleLineString((term.getDescription() != null) ? term.getDescription() : "");
                             out.println(String.format(
                                 RESOURCE_BUNDLE.getString("message.glossary.list_term"), term.getId(), term.getText(), description));
                         }

--- a/src/main/java/com/crowdin/cli/commands/actions/GlossaryUploadAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/GlossaryUploadAction.java
@@ -9,13 +9,10 @@ import com.crowdin.cli.properties.BaseProperties;
 import com.crowdin.client.glossaries.model.AddGlossaryRequest;
 import com.crowdin.client.glossaries.model.Glossary;
 import lombok.NonNull;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static com.crowdin.cli.BaseCli.DEFAULT_GLOSSARY_NAME;
 import static com.crowdin.cli.BaseCli.RESOURCE_BUNDLE;
@@ -25,15 +22,13 @@ class GlossaryUploadAction implements NewAction<BaseProperties, ClientGlossary> 
 
     private final java.io.File file;
     private final Long id;
-    private final String name;
     private final String languageId;
     private final Map<String, Integer> scheme;
     private final Boolean firstLineContainsHeader;
 
-    public GlossaryUploadAction(@NonNull java.io.File file, Long id, String name, String languageId, Map<String, Integer> scheme, Boolean firstLineContainsHeader) {
+    public GlossaryUploadAction(@NonNull java.io.File file, Long id, String languageId, Map<String, Integer> scheme, Boolean firstLineContainsHeader) {
         this.file = file;
         this.id = id;
-        this.name = name;
         this.languageId = languageId;
         this.scheme = scheme;
         this.firstLineContainsHeader = firstLineContainsHeader;
@@ -44,26 +39,11 @@ class GlossaryUploadAction implements NewAction<BaseProperties, ClientGlossary> 
         boolean isOrganization = PropertiesBeanUtils.isOrganization(pb.getBaseUrl());
         Glossary targetGlossary;
         if (id != null) {
-            targetGlossary = client.getGlossary(id)
-                .orElseThrow(() -> new RuntimeException(RESOURCE_BUNDLE.getString("error.glossary.not_found_by_id")));
-        } else if (name != null) {
-            List<Glossary> foundGlossaries = client.listGlossaries().stream()
-                .filter(gl -> gl.getName() != null && gl.getName().equals(name))
-                .collect(Collectors.toList());
-            if (foundGlossaries.isEmpty()) {
-                if (StringUtils.isEmpty(languageId)) {
-                    throw new RuntimeException(RESOURCE_BUNDLE.getString("error.glossary.no_language_id"));
-                }
-                targetGlossary = client.addGlossary(RequestBuilder.addGlossary(name, languageId));
-            } else if (foundGlossaries.size() == 1) {
-                targetGlossary = foundGlossaries.get(0);
-            } else {
-                throw new RuntimeException(RESOURCE_BUNDLE.getString("error.glossary.more_than_one_glossary_by_that_name"));
-            }
+            targetGlossary = client.getGlossary(id);
         } else {
             AddGlossaryRequest addGlossaryRequest = (isOrganization)
-                ? RequestBuilder.addGlossaryEnterprise(String.format(DEFAULT_GLOSSARY_NAME, file.getName()), languageId, 0L)
-                : RequestBuilder.addGlossary(String.format(DEFAULT_GLOSSARY_NAME, file.getName()), languageId);
+                    ? RequestBuilder.addGlossaryEnterprise(String.format(DEFAULT_GLOSSARY_NAME, file.getName()), languageId, 0L)
+                    : RequestBuilder.addGlossary(String.format(DEFAULT_GLOSSARY_NAME, file.getName()), languageId);
             targetGlossary = client.addGlossary(addGlossaryRequest);
         }
         Long storageId;
@@ -74,6 +54,6 @@ class GlossaryUploadAction implements NewAction<BaseProperties, ClientGlossary> 
         }
         client.importGlossary(targetGlossary.getId(), RequestBuilder.importGlossary(storageId, scheme, firstLineContainsHeader));
         out.println(OK.withIcon(
-            String.format(RESOURCE_BUNDLE.getString("message.glossary.import_success"), targetGlossary.getId(), targetGlossary.getName())));
+                String.format(RESOURCE_BUNDLE.getString("message.glossary.import_success"), targetGlossary.getId(), targetGlossary.getName())));
     }
 }

--- a/src/main/java/com/crowdin/cli/commands/actions/TmDownloadAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/TmDownloadAction.java
@@ -24,7 +24,6 @@ import static com.crowdin.cli.BaseCli.RESOURCE_BUNDLE;
 class TmDownloadAction implements NewAction<BaseProperties, ClientTm> {
 
     private final Long id;
-    private final String name;
     private final TranslationMemoryFormat format;
     private final String sourceLanguageId;
     private final String targetLanguageId;
@@ -33,11 +32,10 @@ class TmDownloadAction implements NewAction<BaseProperties, ClientTm> {
     private final FilesInterface files;
 
     public TmDownloadAction(
-        Long id, String name, TranslationMemoryFormat format, String sourceLanguageId,
+        Long id, TranslationMemoryFormat format, String sourceLanguageId,
         String targetLanguageId, boolean noProgress, File to, FilesInterface files
     ) {
         this.id = id;
-        this.name = name;
         this.format = format;
         this.sourceLanguageId = sourceLanguageId;
         this.targetLanguageId = targetLanguageId;
@@ -63,23 +61,8 @@ class TmDownloadAction implements NewAction<BaseProperties, ClientTm> {
     }
 
     private TranslationMemory getTranslationMemory(ClientTm client) {
-        if (id != null) {
-            return client.getTm(id)
+        return client.getTm(id)
                 .orElseThrow(() -> new RuntimeException(RESOURCE_BUNDLE.getString("error.tm.not_found_by_id")));
-        } else if (name != null) {
-            List<TranslationMemory> foundTranslationMemories = client.listTms().stream()
-                .filter(gl -> gl.getName() != null && gl.getName().equals(name))
-                .collect(Collectors.toList());
-            if (foundTranslationMemories.isEmpty()) {
-                throw new RuntimeException(RESOURCE_BUNDLE.getString("error.tm.not_found_by_name"));
-            } else if (foundTranslationMemories.size() == 1) {
-                return foundTranslationMemories.get(0);
-            } else {
-                throw new RuntimeException(RESOURCE_BUNDLE.getString("error.tm.more_than_one_tm_by_that_name"));
-            }
-        } else {
-            throw new RuntimeException("Unexpected error: " + RESOURCE_BUNDLE.getString("error.tm.no_identifiers"));
-        }
     }
 
     private TranslationMemoryExportStatus buildTranslationMemory(Outputter out, ClientTm client, Long tmId, TranslationMemoryExportRequest request) {

--- a/src/main/java/com/crowdin/cli/commands/actions/TmDownloadAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/TmDownloadAction.java
@@ -16,8 +16,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.crowdin.cli.BaseCli.RESOURCE_BUNDLE;
 
@@ -61,8 +59,7 @@ class TmDownloadAction implements NewAction<BaseProperties, ClientTm> {
     }
 
     private TranslationMemory getTranslationMemory(ClientTm client) {
-        return client.getTm(id)
-                .orElseThrow(() -> new RuntimeException(RESOURCE_BUNDLE.getString("error.tm.not_found_by_id")));
+        return client.getTm(id);
     }
 
     private TranslationMemoryExportStatus buildTranslationMemory(Outputter out, ClientTm client, Long tmId, TranslationMemoryExportRequest request) {

--- a/src/main/java/com/crowdin/cli/commands/actions/TmListAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/TmListAction.java
@@ -25,7 +25,7 @@ class TmListAction implements NewAction<BaseProperties, ClientTm> {
         for (TranslationMemory tm : tms) {
             if (!plainView) {
                 out.println(OK.withIcon(
-                    String.format(RESOURCE_BUNDLE.getString("message.tm.list"), tm.getName(), tm.getId(), tm.getSegmentsCount())));
+                    String.format(RESOURCE_BUNDLE.getString("message.tm.list"), tm.getId(), tm.getName(), tm.getSegmentsCount())));
             } else {
                 out.println(tm.getName());
             }

--- a/src/main/java/com/crowdin/cli/commands/actions/TmUploadAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/TmUploadAction.java
@@ -8,14 +8,11 @@ import com.crowdin.cli.commands.functionality.RequestBuilder;
 import com.crowdin.cli.properties.BaseProperties;
 import com.crowdin.client.translationmemory.model.AddTranslationMemoryRequest;
 import com.crowdin.client.translationmemory.model.TranslationMemory;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static com.crowdin.cli.BaseCli.DEFAULT_TM_NAME;
 import static com.crowdin.cli.BaseCli.RESOURCE_BUNDLE;
@@ -25,15 +22,13 @@ class TmUploadAction implements NewAction<BaseProperties, ClientTm> {
 
     private final File file;
     private final Long id;
-    private final String name;
     private final String languageId;
     private final Map<String, Integer> scheme;
     private final Boolean firstLineContainsHeader;
 
-    public TmUploadAction(File file, Long id, String name, String languageId, Map<String, Integer> scheme, Boolean firstLineContainsHeader) {
+    public TmUploadAction(File file, Long id, String languageId, Map<String, Integer> scheme, Boolean firstLineContainsHeader) {
         this.file = file;
         this.id = id;
-        this.name = name;
         this.languageId = languageId;
         this.scheme = scheme;
         this.firstLineContainsHeader = firstLineContainsHeader;
@@ -56,22 +51,7 @@ class TmUploadAction implements NewAction<BaseProperties, ClientTm> {
 
     private TranslationMemory getTm(ClientTm client, boolean isEnterprise) {
         if (id != null) {
-            return client.getTm(id)
-                .orElseThrow(() -> new RuntimeException(RESOURCE_BUNDLE.getString("error.tm.not_found_by_id")));
-        } else if (name != null) {
-            List<TranslationMemory> foundTms = client.listTms().stream()
-                .filter(gl -> gl.getName() != null && gl.getName().equals(name))
-                .collect(Collectors.toList());
-            if (foundTms.isEmpty()) {
-                if (StringUtils.isEmpty(languageId)) {
-                    throw new RuntimeException(RESOURCE_BUNDLE.getString("error.tm.no_language_id"));
-                }
-                return client.addTm(RequestBuilder.addTm(name, languageId));
-            } else if (foundTms.size() == 1) {
-                return foundTms.get(0);
-            } else {
-                throw new RuntimeException(RESOURCE_BUNDLE.getString("error.tm.more_than_one_tm_by_that_name"));
-            }
+            return client.getTm(id);
         } else {
             AddTranslationMemoryRequest addTmRequest = (isEnterprise)
                 ? RequestBuilder.addTmEnterprise(String.format(DEFAULT_TM_NAME, file.getName()), languageId, 0L)

--- a/src/main/java/com/crowdin/cli/commands/picocli/GlossaryDownloadSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/GlossaryDownloadSubcommand.java
@@ -19,11 +19,8 @@ import java.util.List;
 )
 class GlossaryDownloadSubcommand extends ActCommandGlossary {
 
-    @CommandLine.Option(names = {"--id"}, paramLabel = "...", order = -2)
-    private Long id;
-
-    @CommandLine.Option(names = {"--name"}, paramLabel = "...", order = -2)
-    private String name;
+    @CommandLine.Parameters(descriptionKey = "crowdin.glossary.download.id")
+    protected Long id;
 
     @CommandLine.Option(names = {"--format"}, paramLabel = "...", order = -2)
     private GlossariesFormat format;
@@ -33,7 +30,7 @@ class GlossaryDownloadSubcommand extends ActCommandGlossary {
 
     @Override
     protected NewAction<BaseProperties, ClientGlossary> getAction(Actions actions) {
-        return actions.glossaryDownload(id, name, format, noProgress, to, new FsFiles());
+        return actions.glossaryDownload(id, format, noProgress, to, new FsFiles());
     }
 
     @Override
@@ -46,11 +43,6 @@ class GlossaryDownloadSubcommand extends ActCommandGlossary {
             } catch (IllegalArgumentException e) {
                 errors.add(RESOURCE_BUNDLE.getString("error.glossary.wrong_format"));
             }
-        }
-        if (id != null && name != null) {
-            errors.add(RESOURCE_BUNDLE.getString("error.glossary.id_and_name"));
-        } else if (id == null && name == null) {
-            errors.add(RESOURCE_BUNDLE.getString("error.glossary.no_id_and_no_name"));
         }
         return errors;
     }

--- a/src/main/java/com/crowdin/cli/commands/picocli/GlossaryUploadSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/GlossaryUploadSubcommand.java
@@ -25,9 +25,6 @@ class GlossaryUploadSubcommand extends ActCommandGlossary {
     @CommandLine.Option(names = {"--id"}, paramLabel = "...", order = -2)
     private Long id;
 
-    @CommandLine.Option(names = {"--name"}, paramLabel = "...", order = -2)
-    private String name;
-
     @CommandLine.Option(names = {"--language"}, paramLabel = "...", descriptionKey = "crowdin.glossary.upload.language-id", order = -2)
     private String languageId;
 
@@ -39,7 +36,7 @@ class GlossaryUploadSubcommand extends ActCommandGlossary {
 
     @Override
     protected NewAction<BaseProperties, ClientGlossary> getAction(Actions actions) {
-        return actions.glossaryUpload(file, id, name, languageId, scheme, firstLineContainsHeader);
+        return actions.glossaryUpload(file, id, languageId, scheme, firstLineContainsHeader);
     }
 
     @Override
@@ -59,10 +56,7 @@ class GlossaryUploadSubcommand extends ActCommandGlossary {
         if (!equalsAny(FilenameUtils.getExtension(file.getName()), "csv", "xls", "xlsx") && firstLineContainsHeader != null) {
             errors.add(RESOURCE_BUNDLE.getString("error.glossary.first_line_contains_header_and_wrong_format"));
         }
-        if (id != null && name != null) {
-            errors.add(RESOURCE_BUNDLE.getString("error.glossary.id_and_name"));
-        }
-        if (id == null && name == null && languageId == null) {
+        if (id == null && languageId == null) {
             errors.add(RESOURCE_BUNDLE.getString("error.glossary.no_language_id"));
         }
         return errors;

--- a/src/main/java/com/crowdin/cli/commands/picocli/TmDownloadSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/TmDownloadSubcommand.java
@@ -19,11 +19,8 @@ import java.util.List;
 )
 class TmDownloadSubcommand extends ActCommandTm {
 
-    @CommandLine.Option(names = {"--id"}, paramLabel = "...", order = -2)
-    private Long id;
-
-    @CommandLine.Option(names = {"--name"}, paramLabel = "...", order = -2)
-    private String name;
+    @CommandLine.Parameters(descriptionKey = "crowdin.tm.download.id")
+    protected Long id;
 
     @CommandLine.Option(names = {"--source-language-id"}, paramLabel = "...", order = -2)
     private String sourceLanguageId;
@@ -39,7 +36,7 @@ class TmDownloadSubcommand extends ActCommandTm {
 
     @Override
     protected NewAction<BaseProperties, ClientTm> getAction(Actions actions) {
-        return actions.tmDownload(id, name, format, sourceLanguageId, targetLanguageId, noProgress, to, new FsFiles());
+        return actions.tmDownload(id, format, sourceLanguageId, targetLanguageId, noProgress, to, new FsFiles());
     }
 
     @Override
@@ -52,11 +49,6 @@ class TmDownloadSubcommand extends ActCommandTm {
             } catch (IllegalArgumentException e) {
                 errors.add(RESOURCE_BUNDLE.getString("error.tm.wrong_format"));
             }
-        }
-        if (id != null && name != null) {
-            errors.add(RESOURCE_BUNDLE.getString("error.tm.id_and_name"));
-        } else if (id == null && name == null) {
-            errors.add(RESOURCE_BUNDLE.getString("error.tm.no_id_and_no_name"));
         }
         if (sourceLanguageId != null && targetLanguageId == null) {
             errors.add(RESOURCE_BUNDLE.getString("error.tm.target_language_id_is_null"));

--- a/src/main/java/com/crowdin/cli/commands/picocli/TmUploadSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/TmUploadSubcommand.java
@@ -25,9 +25,6 @@ class TmUploadSubcommand extends ActCommandTm {
     @CommandLine.Option(names = {"--id"}, paramLabel = "...", order = -2)
     private Long id;
 
-    @CommandLine.Option(names = {"--name"}, paramLabel = "...", order = -2)
-    private String name;
-
     @CommandLine.Option(names = {"--language"}, paramLabel = "...", descriptionKey = "crowdin.tm.upload.language-id", order = -2)
     private String languageId;
 
@@ -39,7 +36,7 @@ class TmUploadSubcommand extends ActCommandTm {
 
     @Override
     protected NewAction<BaseProperties, ClientTm> getAction(Actions actions) {
-        return actions.tmUpload(file, id, name, languageId, scheme, firstLineContainsHeader);
+        return actions.tmUpload(file, id, languageId, scheme, firstLineContainsHeader);
     }
 
     @Override
@@ -55,7 +52,7 @@ class TmUploadSubcommand extends ActCommandTm {
         if (!equalsAny(FilenameUtils.getExtension(file.getName()), "csv", "xls", "xlsx") && firstLineContainsHeader != null) {
             errors.add(RESOURCE_BUNDLE.getString("error.tm.first_line_contains_header_and_wrong_format"));
         }
-        if (id == null && name == null && languageId == null) {
+        if (id == null && languageId == null) {
             errors.add(RESOURCE_BUNDLE.getString("error.tm.no_language_id"));
         }
         return errors;

--- a/src/main/java/com/crowdin/cli/utils/Utils.java
+++ b/src/main/java/com/crowdin/cli/utils/Utils.java
@@ -178,4 +178,8 @@ public class Utils {
             throw new RuntimeException(e);
         }
     }
+
+    public static String toSingleLineString(String str) {
+        return str.replaceAll("[\r\n]+", " ");
+    }
 }

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -507,9 +507,7 @@ error.status.only_one_allowed=Only one of the following options can be used at a
 
 error.tm.build_tm=Failed to build the translation memory
 error.tm.not_found_by_id=Couldn't find translation memory by the specified ID
-error.tm.not_found_by_name=Couldn't find translation memory by the specified name
 error.tm.more_than_one_tm_by_that_name=There are multiple translation memories with the specified name. Consider using '--id' to identify specific translation memory
-error.tm.no_identifiers=Specify translation memory name or ID
 error.tm.wrong_format=Supported formats: tmx, csv, xlsx
 error.tm.id_and_name='--id' and '--name' can't be specified simultaneously to identify translation memory
 error.tm.no_id_and_no_name='--id' or '--name' should be specified to identify translation memory

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -694,12 +694,12 @@ message.source_string_list_max_length=\t- @|bold max-length|@: %s
 message.source_string_list_not_found=No strings found
 
 message.glossary.download_success=@|green,bold '%s'|@ @|green downloaded successfully|@
-message.glossary.list=Glossary @|green '%s'|@ (@|yellow #%d|@, terms: @|bold %d|@)
+message.glossary.list=@|yellow #%d|@ @|bold '%s'|@ (@|green terms: %d|@)
 message.glossary.list_term=\t@|yellow #%d|@ @|cyan '%s'|@: %s
 message.glossary.import_success=Imported in @|yellow #%s|@ @|green '%s'|@ glossary
 
 message.tm.download_success=@|green,bold '%s'|@ @|green downloaded successfully|@
-message.tm.list=Translation memory @|green %s|@ (@|yellow #%d|@, segments: @|bold %d|@)
+message.tm.list=@|yellow #%d|@ @|bold '%s'|@ (@|green segments: %d|@)
 message.tm.import_success=Imported in @|yellow #%s|@ @|green '%s'|@ translation memory
 message.tm.list_empty=No translation memories found
 

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -503,8 +503,6 @@ error.glossary.no_language_id='--language' is required for creating new glossary
 error.status.only_one_allowed=Only one of the following options can be used at a time: '--file', '--directory'
 
 error.tm.build_tm=Failed to build the translation memory
-error.tm.not_found_by_id=Couldn't find translation memory by the specified ID
-error.tm.more_than_one_tm_by_that_name=There are multiple translation memories with the specified name. Consider using '--id' to identify specific translation memory
 error.tm.wrong_format=Supported formats: tmx, csv, xlsx
 error.tm.id_and_name='--id' and '--name' can't be specified simultaneously to identify translation memory
 error.tm.no_id_and_no_name='--id' or '--name' should be specified to identify translation memory

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -493,7 +493,6 @@ error.glossary.build_glossary=Failed to build the glossary
 error.glossary.not_found_by_name=Couldn't find glossary by the specified name
 error.glossary.no_identifiers=Specify glossary name or ID
 error.glossary.wrong_format=Supported formats: tbx, csv, xlsx
-error.glossary.no_id_and_no_name='--id' or '--name' should be specified to identify glossary
 error.glossary.scheme_and_wrong_format=Scheme is used only for CSV or XLS/XLSX files
 error.glossary.scheme_is_required=Scheme is required for CSV or XLS/XLSX files
 error.glossary.first_line_contains_header_and_wrong_format='--first-line-contains-header' is used only for CSV or XLS/XLSX files
@@ -504,8 +503,6 @@ error.status.only_one_allowed=Only one of the following options can be used at a
 
 error.tm.build_tm=Failed to build the translation memory
 error.tm.wrong_format=Supported formats: tmx, csv, xlsx
-error.tm.id_and_name='--id' and '--name' can't be specified simultaneously to identify translation memory
-error.tm.no_id_and_no_name='--id' or '--name' should be specified to identify translation memory
 error.tm.scheme_is_required=Scheme is required for CSV or XLS/XLSX files
 error.tm.first_line_contains_header_and_wrong_format='--first-line-contains-header' is used only for CSV or XLS/XLSX files
 error.tm.target_language_id_is_null='--target-language-id' must be specified along with '--source-language-id'

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -490,8 +490,6 @@ error.no_files_found_for_pre_translate=Couldn't find any files to Pre-Translate 
 error.project_is_incomplete=The current project is incomplete
 
 error.glossary.build_glossary=Failed to build the glossary
-error.glossary.not_found_by_name=Couldn't find glossary by the specified name
-error.glossary.no_identifiers=Specify glossary name or ID
 error.glossary.wrong_format=Supported formats: tbx, csv, xlsx
 error.glossary.scheme_and_wrong_format=Scheme is used only for CSV or XLS/XLSX files
 error.glossary.scheme_is_required=Scheme is required for CSV or XLS/XLSX files

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -490,12 +490,9 @@ error.no_files_found_for_pre_translate=Couldn't find any files to Pre-Translate 
 error.project_is_incomplete=The current project is incomplete
 
 error.glossary.build_glossary=Failed to build the glossary
-error.glossary.not_found_by_id=Couldn't find glossary by the specified ID
 error.glossary.not_found_by_name=Couldn't find glossary by the specified name
-error.glossary.more_than_one_glossary_by_that_name=There are multiple glossaries with the specified name. Consider using '--id' to identify specific glossary
 error.glossary.no_identifiers=Specify glossary name or ID
 error.glossary.wrong_format=Supported formats: tbx, csv, xlsx
-error.glossary.id_and_name='--id' and '--name' can't be specified simultaneously to identify glossary
 error.glossary.no_id_and_no_name='--id' or '--name' should be specified to identify glossary
 error.glossary.scheme_and_wrong_format=Scheme is used only for CSV or XLS/XLSX files
 error.glossary.scheme_is_required=Scheme is required for CSV or XLS/XLSX files

--- a/src/test/java/com/crowdin/cli/client/CrowdinClientGlossaryTest.java
+++ b/src/test/java/com/crowdin/cli/client/CrowdinClientGlossaryTest.java
@@ -21,9 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -39,8 +37,6 @@ public class CrowdinClientGlossaryTest {
 
     private static final String preUrl = "https://testme.crowdin.com";
     private static final String url = "https://testme.crowdin.com/api/v2";
-
-    private static final String downloadUrl = "https://downloadme.crowdin.com";
     private static final String downloadUrlMalformed = "https";
     private static final long glossaryId = 92;
     private static final String exportGlossaryId = "9-2";
@@ -107,9 +103,8 @@ public class CrowdinClientGlossaryTest {
         when(httpClientMock.get(eq(getGlossaryUrl), any(), eq(GlossaryResponseObject.class)))
             .thenThrow(new RuntimeException("any"));
 
-        Optional<Glossary> result = client.getGlossary(glossaryId);
+        assertThrows(RuntimeException.class, () -> client.getGlossary(glossaryId));
 
-        assertFalse(result.isPresent());
         verify(httpClientMock).get(eq(getGlossaryUrl), any(), eq(GlossaryResponseObject.class));
         verifyNoMoreInteractions(httpClientMock);
     }

--- a/src/test/java/com/crowdin/cli/client/CrowdinClientTmTest.java
+++ b/src/test/java/com/crowdin/cli/client/CrowdinClientTmTest.java
@@ -102,7 +102,7 @@ public class CrowdinClientTmTest {
         when(httpClientMock.get(eq(getTmUrl), any(), eq(TranslationMemoryResponseObject.class)))
             .thenThrow(new RuntimeException("any"));
 
-        client.getTm(tmId);
+        assertThrows(RuntimeException.class, () -> client.getTm(tmId));
 
         verify(httpClientMock).get(eq(getTmUrl), any(), eq(TranslationMemoryResponseObject.class));
         verifyNoMoreInteractions(httpClientMock);

--- a/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
@@ -84,7 +84,7 @@ public class CliActionsTest {
 
     @Test
     public void testGlossaryUpload() {
-        assertNotNull(actions.glossaryUpload(new File("nowhere.txt"), null, null, null, null, null));
+        assertNotNull(actions.glossaryUpload(new File("nowhere.txt"), null, null, null, null));
     }
 
     @Test

--- a/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
@@ -104,7 +104,7 @@ public class CliActionsTest {
 
     @Test
     public void testTmDownload() {
-        assertNotNull(actions.tmDownload(null, null, null, null, null, false, null, null));
+        assertNotNull(actions.tmDownload(null, null, null, null, false, null, null));
     }
 
     @Test

--- a/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
@@ -89,7 +89,7 @@ public class CliActionsTest {
 
     @Test
     public void testGlossaryDownload() {
-        assertNotNull(actions.glossaryDownload(null, null, null, false, null, null));
+        assertNotNull(actions.glossaryDownload(null, null, false, null, null));
     }
 
     @Test

--- a/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
@@ -99,7 +99,7 @@ public class CliActionsTest {
 
     @Test
     public void testTmUpload() {
-        assertNotNull(actions.tmUpload(null, null, null, null, null, null));
+        assertNotNull(actions.tmUpload(null, null, null, null, null));
     }
 
     @Test

--- a/src/test/java/com/crowdin/cli/commands/actions/GlossaryDownloadActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/GlossaryDownloadActionTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -31,9 +29,7 @@ import static org.mockito.Mockito.when;
 public class GlossaryDownloadActionTest {
 
     private static final Long glossaryId = 42L;
-    private static final Long glossaryId2 = 43L;
     private static final String glossaryName = "FirstName";
-    private static final String glossaryName2 = "SecondName";
     private static final String exportId = "52";
     private final BaseProperties pb = NewPropertiesWithFilesUtilBuilder
         .minimalBuiltPropertiesBean()
@@ -71,7 +67,7 @@ public class GlossaryDownloadActionTest {
         when(clientMock.downloadGlossary(eq(glossaryId), eq(exportId)))
             .thenReturn(MockitoUtils.getMockUrl(getClass()));
 
-        NewAction<BaseProperties, ClientGlossary> action = new GlossaryDownloadAction(glossaryId, null, format, true, to, filesMock);
+        NewAction<BaseProperties, ClientGlossary> action = new GlossaryDownloadAction(glossaryId, format, true, to, filesMock);
         action.act(outputter, pb, clientMock);
 
         verify(filesMock).writeToFile(eq("nowhere.tbx"), any());
@@ -85,112 +81,14 @@ public class GlossaryDownloadActionTest {
     }
 
     @Test
-    public void test_findByName() throws IOException {
-        FilesInterface filesMock = mock(FilesInterface.class);
-        ClientGlossary clientMock = mock(ClientGlossary.class);
-        GlossariesFormat format = GlossariesFormat.TBX;
-
-        List<Glossary> glossaries = Arrays.asList(
-            new Glossary() {{
-                    setId(glossaryId);
-                    setName(glossaryName);
-                }},
-            new Glossary() {{
-                    setId(glossaryId2);
-                    setName(glossaryName2);
-                }}
-        );
-        GlossaryExportStatus buildingGlossary1 = new GlossaryExportStatus() {{
-                setIdentifier(exportId);
-                setStatus("Is building");
-            }};
-        GlossaryExportStatus buildingGlossary2 = new GlossaryExportStatus() {{
-                setIdentifier(exportId);
-                setStatus("Finished");
-            }};
-
-        when(clientMock.listGlossaries())
-            .thenReturn(glossaries);
-        when(clientMock.startExportingGlossary(eq(glossaryId), eq(RequestBuilder.exportGlossary(format))))
-            .thenReturn(buildingGlossary1);
-        when(clientMock.checkExportingGlossary(eq(glossaryId), eq(exportId)))
-            .thenReturn(buildingGlossary2);
-        when(clientMock.downloadGlossary(eq(glossaryId), eq(exportId)))
-            .thenReturn(MockitoUtils.getMockUrl(getClass()));
-
-        NewAction<BaseProperties, ClientGlossary> action = new GlossaryDownloadAction(null, glossaryName, format, true, null, filesMock);
-        action.act(outputter, pb, clientMock);
-
-        verify(filesMock).writeToFile(eq(glossaryName + ".tbx"), any());
-        verifyNoMoreInteractions(filesMock);
-        verify(clientMock).listGlossaries();
-        verify(clientMock).startExportingGlossary(eq(glossaryId), eq(RequestBuilder.exportGlossary(format)));
-        verify(clientMock).startExportingGlossary(eq(glossaryId), eq(RequestBuilder.exportGlossary(format)));
-        verify(clientMock).checkExportingGlossary(eq(glossaryId), eq(exportId));
-        verify(clientMock).downloadGlossary(eq(glossaryId), eq(exportId));
-        verifyNoMoreInteractions(clientMock);
-    }
-
-    @Test
-    public void test_findByName_throwsNoGlossaries() {
-        FilesInterface filesMock = mock(FilesInterface.class);
-        ClientGlossary clientMock = mock(ClientGlossary.class);
-
-        List<Glossary> glossaries = Arrays.asList(
-            new Glossary() {{
-                    setId(glossaryId);
-                    setName(glossaryName2);
-                }},
-            new Glossary() {{
-                    setId(glossaryId2);
-                    setName(glossaryName2);
-                }}
-        );
-
-        when(clientMock.listGlossaries())
-            .thenReturn(glossaries);
-
-        NewAction<BaseProperties, ClientGlossary> action = new GlossaryDownloadAction(null, glossaryName, null, true, null, filesMock);
-        assertThrows(RuntimeException.class, () -> action.act(outputter, pb, clientMock));
-
-        verify(clientMock).listGlossaries();
-        verifyNoMoreInteractions(clientMock);
-    }
-
-    @Test
-    public void test_findByName_throwsTooManyGlossaries() {
-        FilesInterface filesMock = mock(FilesInterface.class);
-        ClientGlossary clientMock = mock(ClientGlossary.class);
-
-        List<Glossary> glossaries = Arrays.asList(
-            new Glossary() {{
-                    setId(glossaryId);
-                    setName(glossaryName);
-                }},
-            new Glossary() {{
-                    setId(glossaryId2);
-                    setName(glossaryName);
-                }}
-        );
-
-        when(clientMock.listGlossaries())
-            .thenReturn(glossaries);
-
-        NewAction<BaseProperties, ClientGlossary> action = new GlossaryDownloadAction(null, glossaryName, null, true, null, filesMock);
-        assertThrows(RuntimeException.class, () -> action.act(outputter, pb, clientMock));
-
-        verify(clientMock).listGlossaries();
-        verifyNoMoreInteractions(clientMock);
-    }
-
-    @Test
     public void test_throwsNoIdentifiers() {
         FilesInterface filesMock = mock(FilesInterface.class);
         ClientGlossary clientMock = mock(ClientGlossary.class);
 
-        NewAction<BaseProperties, ClientGlossary> action = new GlossaryDownloadAction(null, null, null, true, null, filesMock);
+        NewAction<BaseProperties, ClientGlossary> action = new GlossaryDownloadAction(null, null, true, null, filesMock);
         assertThrows(RuntimeException.class, () -> action.act(outputter, pb, clientMock));
 
+        verify(clientMock).getGlossary(any());
         verifyNoMoreInteractions(clientMock);
     }
 
@@ -228,7 +126,7 @@ public class GlossaryDownloadActionTest {
         when(clientMock.downloadGlossary(eq(glossaryId), eq(exportId)))
             .thenReturn(MockitoUtils.getMockUrl(getClass()));
 
-        NewAction<BaseProperties, ClientGlossary> action = new GlossaryDownloadAction(glossaryId, null, format, true, to, filesMock);
+        NewAction<BaseProperties, ClientGlossary> action = new GlossaryDownloadAction(glossaryId, format, true, to, filesMock);
         assertThrows(RuntimeException.class, () -> action.act(outputter, pb, clientMock));
 
         verify(filesMock).writeToFile(eq("nowhere.tbx"), any());

--- a/src/test/java/com/crowdin/cli/commands/actions/GlossaryDownloadActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/GlossaryDownloadActionTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,11 +43,10 @@ public class GlossaryDownloadActionTest {
         File to = new File("nowhere.tbx");
         GlossariesFormat format = GlossariesFormat.TBX;
 
-        Optional<Glossary> targetGlossary = Optional.of(new Glossary() {{
+        Glossary targetGlossary = new Glossary() {{
                 setId(glossaryId);
                 setName(glossaryName);
-            }}
-        );
+            }};
         GlossaryExportStatus buildingGlossary1 = new GlossaryExportStatus() {{
                 setIdentifier(exportId);
                 setStatus("Is building");
@@ -99,11 +97,10 @@ public class GlossaryDownloadActionTest {
         File to = new File("nowhere.tbx");
         GlossariesFormat format = GlossariesFormat.TBX;
 
-        Optional<Glossary> targetGlossary = Optional.of(new Glossary() {{
+        Glossary targetGlossary = new Glossary() {{
                 setId(glossaryId);
                 setName(glossaryName);
-            }}
-        );
+            }};
         GlossaryExportStatus buildingGlossary1 = new GlossaryExportStatus() {{
                 setIdentifier(exportId);
                 setStatus("Is building");

--- a/src/test/java/com/crowdin/cli/commands/actions/GlossaryUploadActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/GlossaryUploadActionTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -30,7 +29,6 @@ public class GlossaryUploadActionTest {
     private static final Long storageId = 52L;
     private static final String glossaryNameUnique = "uniqueGlossary";
     private static final String glossaryNameRepeated = "twoGlossariesWithSameName";
-    private static final String glossaryNameNotExist = "notExistentGlossary";
     BaseProperties pb = NewBasePropertiesUtilBuilder
         .minimalBuilt()
         .build();
@@ -62,10 +60,11 @@ public class GlossaryUploadActionTest {
                 setId(glossaryId);
                 setName("New glossary");
             }};
+
         when(clientMock.getGlossary(eq(glossaryIdNotExist)))
-            .thenReturn(Optional.empty());
+            .thenThrow(new RuntimeException());
         when(clientMock.getGlossary(eq(glossaryId)))
-            .thenReturn(Optional.of(glossary));
+            .thenReturn(glossary);
         when(clientMock.listGlossaries())
             .thenReturn(glossaries);
         when(clientMock.uploadStorage(any(), any()))
@@ -79,7 +78,7 @@ public class GlossaryUploadActionTest {
 
     @Test
     public void test_withId() {
-        action = new GlossaryUploadAction(file, glossaryId, null, null, null, null);
+        action = new GlossaryUploadAction(file, glossaryId, null, null, null);
         action.act(Outputter.getDefault(), pb, clientMock);
 
         verify(clientMock).getGlossary(eq(glossaryId));
@@ -89,19 +88,8 @@ public class GlossaryUploadActionTest {
     }
 
     @Test
-    public void test_withName() {
-        action = new GlossaryUploadAction(file, null, glossaryNameUnique, null, null, null);
-        action.act(Outputter.getDefault(), pb, clientMock);
-
-        verify(clientMock).listGlossaries();
-        verify(clientMock).uploadStorage(any(), any());
-        verify(clientMock).importGlossary(eq(glossaryId), any());
-        verifyNoMoreInteractions(clientMock);
-    }
-
-    @Test
     public void test_noIdentifiers_createNew() {
-        action = new GlossaryUploadAction(file, null, null, null, null, null);
+        action = new GlossaryUploadAction(file, null, null, null, null);
         action.act(Outputter.getDefault(), pb, clientMock);
 
         verify(clientMock).addGlossary(any());
@@ -111,17 +99,8 @@ public class GlossaryUploadActionTest {
     }
 
     @Test
-    public void test_withName_notFound_createNew() {
-        action = new GlossaryUploadAction(file, null, glossaryNameNotExist, null, null, null);
-        assertThrows(RuntimeException.class, () -> action.act(Outputter.getDefault(), pb, clientMock));
-
-        verify(clientMock).listGlossaries();
-        verifyNoMoreInteractions(clientMock);
-    }
-
-    @Test
     public void test_withId_throwsNotFound() {
-        action = new GlossaryUploadAction(file, glossaryIdNotExist, null, null, null, null);
+        action = new GlossaryUploadAction(file, glossaryIdNotExist, null, null, null);
         assertThrows(RuntimeException.class, () -> action.act(Outputter.getDefault(), pb, clientMock));
 
         verify(clientMock).getGlossary(eq(glossaryIdNotExist));
@@ -129,17 +108,8 @@ public class GlossaryUploadActionTest {
     }
 
     @Test
-    public void test_withName_throwsTooManyWithTargetName() {
-        action = new GlossaryUploadAction(file, null, glossaryNameRepeated, null, null, null);
-        assertThrows(RuntimeException.class, () -> action.act(Outputter.getDefault(), pb, clientMock));
-
-        verify(clientMock).listGlossaries();
-        verifyNoMoreInteractions(clientMock);
-    }
-
-    @Test
     public void test_standard_throwsFileNotFound() {
-        action = new GlossaryUploadAction(fileNotExist, glossaryId, null, null, null, null);
+        action = new GlossaryUploadAction(fileNotExist, glossaryId, null, null, null);
         assertThrows(RuntimeException.class, () -> action.act(Outputter.getDefault(), pb, clientMock));
 
         verify(clientMock).getGlossary(eq(glossaryId));

--- a/src/test/java/com/crowdin/cli/commands/actions/TmDownloadActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/TmDownloadActionTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
@@ -28,7 +27,6 @@ public class TmDownloadActionTest {
     private final Long tmIdNotExist = 45L;
     private final String tmNameValid = "42";
     private final String tmNameRepeats = "43";
-    private final String tmNameNotExist = "45";
     private final String exportIdentifier = "exportIdentifier";
     private final File to = new File("somewhere.tmx");
 
@@ -52,11 +50,11 @@ public class TmDownloadActionTest {
             }};
 //        client.getTm
         when(clientMock.getTm(eq(tmIdValid)))
-            .thenReturn(Optional.of(tmValid));
+            .thenReturn(tmValid);
         when(clientMock.getTm(eq(tmIdRepeats)))
-            .thenReturn(Optional.of(tmRepeats));
+            .thenReturn(tmRepeats);
         when(clientMock.getTm(eq(tmIdNotExist)))
-            .thenReturn(Optional.empty());
+            .thenThrow(new RuntimeException());
 //        client.listTms
         when(clientMock.listTms())
             .thenReturn(Arrays.asList(tmValid, tmRepeats, tmRepeats));

--- a/src/test/java/com/crowdin/cli/commands/actions/TmDownloadActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/TmDownloadActionTest.java
@@ -18,15 +18,8 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 public class TmDownloadActionTest {
 
@@ -90,7 +83,7 @@ public class TmDownloadActionTest {
 
     @Test
     public void test_findById() throws IOException {
-        action = new TmDownloadAction(tmIdValid, null, null, null, null, false, this.to, filesMock);
+        action = new TmDownloadAction(tmIdValid, null, null, null, false, this.to, filesMock);
         action.act(out, pb, clientMock);
 
         verify(clientMock).getTm(eq(tmIdValid));
@@ -103,7 +96,7 @@ public class TmDownloadActionTest {
 
     @Test
     public void test_findById_throwsNotFound() {
-        action = new TmDownloadAction(tmIdNotExist, null, null, null, null, false, this.to, filesMock);
+        action = new TmDownloadAction(tmIdNotExist, null, null, null, false, this.to, filesMock);
         assertThrows(RuntimeException.class, () -> action.act(out, pb, clientMock));
 
         verify(clientMock).getTm(eq(tmIdNotExist));
@@ -112,50 +105,18 @@ public class TmDownloadActionTest {
     }
 
     @Test
-    public void test_findByName() throws IOException {
-        action = new TmDownloadAction(null, tmNameValid, null, null, null, false, this.to, filesMock);
-        action.act(out, pb, clientMock);
-
-        verify(clientMock).listTms();
-        verify(clientMock).startExportingTm(eq(tmIdValid), any());
-        verify(clientMock).downloadTm(eq(tmIdValid), eq(exportIdentifier));
-        verifyNoMoreInteractions(clientMock);
-        verify(filesMock).writeToFile(anyString(), any());
-        verifyNoMoreInteractions(filesMock);
-    }
-
-    @Test
-    public void test_findByName_throwsNoTms() {
-        action = new TmDownloadAction(null, tmNameNotExist, null, null, null, false, this.to, filesMock);
-        assertThrows(RuntimeException.class, () -> action.act(out, pb, clientMock));
-
-        verify(clientMock).listTms();
-        verifyNoMoreInteractions(clientMock);
-        verifyNoMoreInteractions(filesMock);
-    }
-
-    @Test
-    public void test_findByName_throwsTooManyTms() {
-        action = new TmDownloadAction(null, tmNameRepeats, null, null, null, false, this.to, filesMock);
-        assertThrows(RuntimeException.class, () -> action.act(out, pb, clientMock));
-
-        verify(clientMock).listTms();
-        verifyNoMoreInteractions(clientMock);
-        verifyNoMoreInteractions(filesMock);
-    }
-
-    @Test
     public void test_throwsNoIdentifiers() {
-        action = new TmDownloadAction(null, null, null, null, null, false, this.to, filesMock);
+        action = new TmDownloadAction(null, null, null, null, false, this.to, filesMock);
         assertThrows(RuntimeException.class, () -> action.act(out, pb, clientMock));
 
+        verify(clientMock).getTm(any());
         verifyNoMoreInteractions(clientMock);
         verifyNoMoreInteractions(filesMock);
     }
 
     @Test
     public void test_longBuild() throws IOException {
-        action = new TmDownloadAction(tmIdRepeats, null, null, null, null, false, this.to, filesMock);
+        action = new TmDownloadAction(tmIdRepeats, null, null, null, false, this.to, filesMock);
         action.act(out, pb, clientMock);
 
         verify(clientMock).getTm(eq(tmIdRepeats));
@@ -173,7 +134,7 @@ public class TmDownloadActionTest {
             .when(filesMock)
             .writeToFile(anyString(), any());
 
-        action = new TmDownloadAction(tmIdValid, null, null, null, null, false, this.to, filesMock);
+        action = new TmDownloadAction(tmIdValid, null, null, null, false, this.to, filesMock);
         assertThrows(RuntimeException.class, () -> action.act(out, pb, clientMock));
 
         verify(clientMock).getTm(eq(tmIdValid));
@@ -186,7 +147,7 @@ public class TmDownloadActionTest {
 
     @Test
     public void test_toIsNull() throws IOException {
-        action = new TmDownloadAction(tmIdValid, null, null, null, null, false, null, filesMock);
+        action = new TmDownloadAction(tmIdValid, null, null, null, false, null, filesMock);
         action.act(out, pb, clientMock);
 
         verify(clientMock).getTm(eq(tmIdValid));

--- a/src/test/java/com/crowdin/cli/commands/actions/TmUploadActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/TmUploadActionTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -57,9 +56,9 @@ public class TmUploadActionTest {
             }};
 //        client.getTm()
         when(clientMock.getTm(eq(tmIdExists)))
-            .thenReturn(Optional.of(tmExists));
+            .thenReturn(tmExists);
         when(clientMock.getTm(eq(tmIdNotExists)))
-            .thenReturn(Optional.empty());
+            .thenThrow(new RuntimeException());
 //        client.listTms()
         when(clientMock.listTms())
             .thenReturn(Arrays.asList(tmExists, tmRepeats, tmRepeats));
@@ -73,7 +72,7 @@ public class TmUploadActionTest {
 
     @Test
     public void test_findById() {
-        action = new TmUploadAction(file, tmIdExists, null, null, null, null);
+        action = new TmUploadAction(file, tmIdExists, null, null, null);
         action.act(out, pb, clientMock);
 
         verify(clientMock).getTm(eq(tmIdExists));
@@ -84,7 +83,7 @@ public class TmUploadActionTest {
 
     @Test
     public void test_findById_throwsNotExists() {
-        action = new TmUploadAction(file, tmIdNotExists, null, null, null, null);
+        action = new TmUploadAction(file, tmIdNotExists, null, null, null);
         assertThrows(RuntimeException.class, () -> action.act(out, pb, clientMock));
 
         verify(clientMock).getTm(eq(tmIdNotExists));
@@ -92,37 +91,8 @@ public class TmUploadActionTest {
     }
 
     @Test
-    public void test_findByName() {
-        action = new TmUploadAction(file, null, tmNameExists, null, null, null);
-        action.act(out, pb, clientMock);
-
-        verify(clientMock).listTms();
-        verify(clientMock).uploadStorage(anyString(), any());
-        verify(clientMock).importTm(eq(tmIdExists), any());
-        verifyNoMoreInteractions(clientMock);
-    }
-
-    @Test
-    public void test_findByName_notExists_throws() {
-        action = new TmUploadAction(file, null, tmNameNotExists, null, null, null);
-        assertThrows(RuntimeException.class, () -> action.act(out, pb, clientMock));
-
-        verify(clientMock).listTms();
-        verifyNoMoreInteractions(clientMock);
-    }
-
-    @Test
-    public void test_findByName_throwsToManyTms() {
-        action = new TmUploadAction(file, null, tmNameRepeats, null, null, null);
-        assertThrows(RuntimeException.class, () -> action.act(out, pb, clientMock));
-
-        verify(clientMock).listTms();
-        verifyNoMoreInteractions(clientMock);
-    }
-
-    @Test
     public void test_noIdentifiers() {
-        action = new TmUploadAction(file, null, null, null, null, null);
+        action = new TmUploadAction(file, null, null, null, null);
         action.act(out, pb, clientMock);
 
         verify(clientMock).addTm(any());
@@ -135,7 +105,7 @@ public class TmUploadActionTest {
     public void test_throwsUploadStorage() {
         when(clientMock.uploadStorage(anyString(), any()))
             .thenThrow(new RuntimeException());
-        action = new TmUploadAction(file, tmIdExists, null, null, null, null);
+        action = new TmUploadAction(file, tmIdExists, null, null, null);
         assertThrows(RuntimeException.class, () -> action.act(out, pb, clientMock));
 
         verify(clientMock).getTm(eq(tmIdExists));

--- a/src/test/java/com/crowdin/cli/commands/picocli/GlossaryDownloadSubcommandTest.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/GlossaryDownloadSubcommandTest.java
@@ -13,28 +13,23 @@ public class GlossaryDownloadSubcommandTest extends PicocliTestUtils {
 
     @Test
     public void testGlossaryDownload() {
-        this.execute(CommandNames.GLOSSARY, CommandNames.GLOSSARY_DOWNLOAD, "--id", "42", "--debug");
+        this.execute(CommandNames.GLOSSARY, CommandNames.GLOSSARY_DOWNLOAD, "42", "--debug");
         verify(actionsMock)
-            .glossaryDownload(eq(42L), isNull(), isNull(), anyBoolean(), isNull(), any());
+            .glossaryDownload(eq(42L), isNull(), anyBoolean(), isNull(), any());
         this.check(true);
     }
 
     @Test
     public void testGlossaryDownload_fileWithExt() {
-        this.execute(CommandNames.GLOSSARY, CommandNames.GLOSSARY_DOWNLOAD, "--id", "42", "--debug", "--to", "file.tbx");
+        this.execute(CommandNames.GLOSSARY, CommandNames.GLOSSARY_DOWNLOAD, "42", "--debug", "--to", "file.tbx");
         verify(actionsMock)
-            .glossaryDownload(eq(42L), isNull(), eq(GlossariesFormat.TBX), anyBoolean(), any(), any());
+            .glossaryDownload(eq(42L), eq(GlossariesFormat.TBX), anyBoolean(), any(), any());
         this.check(true);
     }
 
     @Test
     public void testGlossaryDownload_invalid_fileWithWrongExt() {
-        this.executeInvalidParams(CommandNames.GLOSSARY, CommandNames.GLOSSARY_DOWNLOAD, "--id", "42", "--debug", "--to", "file.txt");
-    }
-
-    @Test
-    public void testGlossaryDownload_invalid_bothIdentifiers() {
-        this.executeInvalidParams(CommandNames.GLOSSARY, CommandNames.GLOSSARY_DOWNLOAD, "--id", "42", "--name", "glossaryName", "--debug");
+        this.executeInvalidParams(CommandNames.GLOSSARY, CommandNames.GLOSSARY_DOWNLOAD, "42", "--debug", "--to", "file.txt");
     }
 
     @Test

--- a/src/test/java/com/crowdin/cli/commands/picocli/PicocliTestUtils.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/PicocliTestUtils.java
@@ -134,7 +134,7 @@ public class PicocliTestUtils {
                 .thenReturn(actionMock);
         when(actionsMock.commentList(anyBoolean(), anyBoolean(),any(),any(),any(),any()))
                 .thenReturn(actionMock);
-        when(actionsMock.tmUpload(any(), any(), any(), any(), any(), any()))
+        when(actionsMock.tmUpload(any(), any(), any(), any(), any()))
             .thenReturn(actionMock);
         when(actionsMock.checkNewVersion())
             .thenReturn(actionMock);

--- a/src/test/java/com/crowdin/cli/commands/picocli/PicocliTestUtils.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/PicocliTestUtils.java
@@ -90,7 +90,7 @@ public class PicocliTestUtils {
             .thenReturn(actionMock);
         when(actionsMock.glossaryUpload(any(), any(), any(), any(), any(), any()))
             .thenReturn(actionMock);
-        when(actionsMock.glossaryDownload(any(), any(), any(), anyBoolean(), any(), any()))
+        when(actionsMock.glossaryDownload(any(), any(), anyBoolean(), any(), any()))
             .thenReturn(actionMock);
         when(actionsMock.tmDownload(any(), any(), any(), any(), anyBoolean(), any(), any()))
             .thenReturn(actionMock);

--- a/src/test/java/com/crowdin/cli/commands/picocli/PicocliTestUtils.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/PicocliTestUtils.java
@@ -88,7 +88,7 @@ public class PicocliTestUtils {
             .thenReturn(actionMock);
         when(actionsMock.glossaryList(anyBoolean(), anyBoolean()))
             .thenReturn(actionMock);
-        when(actionsMock.glossaryUpload(any(), any(), any(), any(), any(), any()))
+        when(actionsMock.glossaryUpload(any(), any(), any(), any(), any()))
             .thenReturn(actionMock);
         when(actionsMock.glossaryDownload(any(), any(), anyBoolean(), any(), any()))
             .thenReturn(actionMock);

--- a/src/test/java/com/crowdin/cli/commands/picocli/PicocliTestUtils.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/PicocliTestUtils.java
@@ -92,7 +92,7 @@ public class PicocliTestUtils {
             .thenReturn(actionMock);
         when(actionsMock.glossaryDownload(any(), any(), any(), anyBoolean(), any(), any()))
             .thenReturn(actionMock);
-        when(actionsMock.tmDownload(any(), any(), any(), any(), any(), anyBoolean(), any(), any()))
+        when(actionsMock.tmDownload(any(), any(), any(), any(), anyBoolean(), any(), any()))
             .thenReturn(actionMock);
         when(actionsMock.tmList(anyBoolean()))
             .thenReturn(actionMock);

--- a/src/test/java/com/crowdin/cli/commands/picocli/TmDownloadSubcommandTest.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/TmDownloadSubcommandTest.java
@@ -12,17 +12,17 @@ public class TmDownloadSubcommandTest extends PicocliTestUtils {
 
     @Test
     public void testGlossaryDownload() {
-        this.execute(CommandNames.TM, CommandNames.TM_DOWNLOAD, "--id", "42", "--debug");
+        this.execute(CommandNames.TM, CommandNames.TM_DOWNLOAD, "42", "--debug");
         verify(actionsMock)
-            .tmDownload(eq(42L), isNull(), isNull(), isNull(), isNull(), eq(false), isNull(), any());
+            .tmDownload(eq(42L), isNull(), isNull(), isNull(), eq(false), isNull(), any());
         this.check(true);
     }
 
     @Test
     public void testGlossaryDownload_withExt() {
-        this.execute(CommandNames.TM, CommandNames.TM_DOWNLOAD, "--id", "42", "--debug", "--to", "file.tmx");
+        this.execute(CommandNames.TM, CommandNames.TM_DOWNLOAD, "42", "--debug", "--to", "file.tmx");
         verify(actionsMock)
-            .tmDownload(eq(42L), isNull(), eq(TranslationMemoryFormat.TMX), isNull(), isNull(), eq(false), any(), any());
+            .tmDownload(eq(42L), eq(TranslationMemoryFormat.TMX), isNull(), isNull(), eq(false), any(), any());
         this.check(true);
     }
 

--- a/src/test/java/com/crowdin/cli/commands/picocli/TmUploadSubcommandTest.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/TmUploadSubcommandTest.java
@@ -13,7 +13,7 @@ public class TmUploadSubcommandTest extends PicocliTestUtils {
     public void testTmUpload() {
         this.execute(CommandNames.TM, CommandNames.TM_UPLOAD, "file.tmx", "--id", "42", "--debug");
         verify(actionsMock)
-            .tmUpload(any(), eq(42L), isNull(), isNull(), isNull(), isNull());
+            .tmUpload(any(), eq(42L), isNull(), isNull(), isNull());
         this.check(true);
     }
 

--- a/src/test/java/com/crowdin/cli/utils/UtilsTest.java
+++ b/src/test/java/com/crowdin/cli/utils/UtilsTest.java
@@ -113,4 +113,16 @@ public class UtilsTest {
     public void testEncodeURL() {
         assertEquals("Hello+World", Utils.encodeURL("Hello World"));
     }
+
+    @Test
+    public void testToSingleLineString() {
+        assertEquals("", Utils.toSingleLineString(""));
+        assertEquals("TesT", Utils.toSingleLineString("TesT"));
+        String multiline = "line 1" +
+                System.lineSeparator() +
+                "line 2" +
+                System.lineSeparator() +
+                "line 3";
+        assertEquals("line 1 line 2 line 3", Utils.toSingleLineString(multiline));
+    }
 }

--- a/website/docs/releases/migration-4.md
+++ b/website/docs/releases/migration-4.md
@@ -2,3 +2,52 @@
 
 This guide is intended to help you migrate from CLI 3.x to 4.x. It is not a comprehensive guide, but rather a list of the most important changes.
 
+### Glossary updates
+
+* removed `name` prop from upload and download commands
+* moved `id` to arguments (only for download commands)
+* updated `list` cmd output
+
+Before:
+
+- `crowdin glossary download --id <id>` or `crowdin glossary download --name <name>`
+- `crowdin glossary upload --id <id>` or `crowdin glossary upload --name <name>`
+
+After:
+
+(Use `list` command to get id)
+
+- `crowdin glossary download <id>`
+- `crowdin glossary upload --id <id>`
+
+### TM updates
+
+* removed `name` prop from upload and download commands
+* moved `id` to arguments (only for download commands)
+* updated `list` cmd output
+
+Before:
+
+- `crowdin tm download --id <id>` or `crowdin tm download --name <name>`
+- `crowdin tm upload --id <id>` or `crowdin tm upload --name <name>`
+
+After:
+
+(Use `list` command to get id)
+
+- `crowdin tm download <id>`
+- `crowdin tm upload --id <id>`
+
+### Screenshots updates
+
+Replaced `name` parameter with `id` to delete screenshot
+
+Before:
+
+- `crowdin screenshot delete <name>`
+
+After:
+
+(Use `list` command to get id)
+
+- `crowdin screenshot delete <id>`


### PR DESCRIPTION
* removed `name` prop (from upload and download commands)
* moved `id` to arguments (only for download commands)
* updated `list` cmd output

Before:

- `crowdin tm download --id <id>` or `crowdin tm download --name <name>`
- `crowdin glossary download --id <id>` or `crowdin glossary download --name <name>`

After:

(Use `list` command to get id)

- `crowdin tm download <id>`
- `crowdin glossary download <id>`