### PR TITLE
fix: correct detection of obsolete files

### DIFF
--- a/src/main/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtils.java
+++ b/src/main/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtils.java
@@ -17,13 +17,14 @@ public class ObsoleteSourcesUtils {
 
     public static Map<String, File> findObsoleteProjectFiles(
         @NonNull Map<String, File> projectFiles, boolean preserveHierarchy,
-        @NonNull List<String> filesToUpload, @NonNull String pattern, @NonNull String exportPattern, List<String> ignorePattern
+        @NonNull List<String> filesToUpload, @NonNull String sourcePattern, @NonNull String exportPattern, List<String> ignorePatterns
     ) {
         Predicate<String> patternCheck =
-            ProjectFilesUtils.isProjectFilePathSatisfiesPatterns(pattern, ignorePattern, preserveHierarchy);
+            ProjectFilesUtils.isProjectFilePathSatisfiesPatterns(sourcePattern, ignorePatterns, preserveHierarchy);
         return projectFiles.entrySet().stream()
-            .filter(entry -> patternCheck.test(entry.getKey()) && checkExportPattern(exportPattern, entry.getValue()))
-            .filter(entry -> isFileDontHaveUpdate(filesToUpload, entry.getKey(), preserveHierarchy))
+            .filter(entry -> patternCheck.test(entry.getKey()))
+            .filter(entry -> checkExportPattern(exportPattern, entry.getValue()))
+            .filter(entry -> isFileNotInList(filesToUpload, entry.getKey(), preserveHierarchy))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
@@ -74,7 +75,7 @@ public class ObsoleteSourcesUtils {
         return obsoleteDirs;
     }
 
-    private static boolean isFileDontHaveUpdate(List<String> filesToUpload, String filePath, boolean preserveHierarchy) {
+    private static boolean isFileNotInList(List<String> filesToUpload, String filePath, boolean preserveHierarchy) {
         String filePathRegex = "^" + (preserveHierarchy ? "" : Utils.PRESERVE_HIERARCHY_REGEX_PART) + Utils.regexPath(filePath) + "$";
         return filesToUpload.stream()
             .noneMatch(Pattern.compile(filePathRegex).asPredicate());

--- a/src/main/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtils.java
+++ b/src/main/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtils.java
@@ -22,9 +22,17 @@ public class ObsoleteSourcesUtils {
         Predicate<String> patternCheck =
             ProjectFilesUtils.isProjectFilePathSatisfiesPatterns(pattern, ignorePattern, preserveHierarchy);
         return projectFiles.entrySet().stream()
-            .filter(entry -> patternCheck.test(entry.getKey()))
+            .filter(entry -> patternCheck.test(entry.getKey()) && checkExportPattern(exportPattern, entry.getValue()))
             .filter(entry -> isFileDontHaveUpdate(filesToUpload, entry.getKey(), preserveHierarchy))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static boolean checkExportPattern(String exportPattern, File file) {
+        String fileExportPattern = ProjectFilesUtils.getExportPattern(file.getExportOptions());
+        if (fileExportPattern == null) {
+            return true;
+        }
+        return exportPattern.equals(Utils.normalizePath(fileExportPattern));
     }
 
     public static SortedMap<String, Long> findObsoleteProjectDirectories(

--- a/src/main/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtils.java
+++ b/src/main/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtils.java
@@ -22,14 +22,9 @@ public class ObsoleteSourcesUtils {
         Predicate<String> patternCheck =
             ProjectFilesUtils.isProjectFilePathSatisfiesPatterns(pattern, ignorePattern, preserveHierarchy);
         return projectFiles.entrySet().stream()
-            .filter(entry -> patternCheck.test(entry.getKey()) && checkExportPattern(exportPattern, entry.getValue()))
+            .filter(entry -> patternCheck.test(entry.getKey()))
             .filter(entry -> isFileDontHaveUpdate(filesToUpload, entry.getKey(), preserveHierarchy))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
-
-    private static boolean checkExportPattern(String exportPattern, File file) {
-        String fileExportPattern = ProjectFilesUtils.getExportPattern(file.getExportOptions());
-        return exportPattern.equals(fileExportPattern != null ? Utils.normalizePath(fileExportPattern) : null);
     }
 
     public static SortedMap<String, Long> findObsoleteProjectDirectories(

--- a/src/test/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtilsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtilsTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ObsoleteSourcesUtilsTest {
 
     @Test
-    public void testCreatePath_PathExists() {
+    public void testFindObsoleteProjectFiles() {
         Map<String, File> projectFiles = new HashMap<String, File>() {
             {
                 put(Utils.normalizePath("test/en/test.md"), new File());
@@ -33,6 +33,7 @@ public class ObsoleteSourcesUtilsTest {
                 filesToUpload, pattern, exportPattern, ignorePattern);
 
         assertEquals(1, obsoleteFiles.size());
+        assertEquals(true, obsoleteFiles.containsKey(Utils.normalizePath("test/en/support.md")));
     }
 
 }

--- a/src/test/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtilsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtilsTest.java
@@ -16,7 +16,7 @@ public class ObsoleteSourcesUtilsTest {
 
     @Test
     public void testFindObsoleteProjectFiles() {
-        Map<String, File> projectFiles = new HashMap<String, File>() {
+        Map<String, File> projectFilesFromApi = new HashMap<String, File>() {
             {
                 put(Utils.normalizePath("test/en/test.md"), new File());
                 put(Utils.normalizePath("test/en/support.md"), new File());
@@ -26,12 +26,13 @@ public class ObsoleteSourcesUtilsTest {
         boolean preserveHierarchy = true;
         List<String> filesToUpload = Arrays.asList(Utils.normalizePath("test/en/test.md"),
                 Utils.normalizePath("test/en/help.md"));
-        String pattern = "/test/en/*.md";
-        String exportPattern = "/test/%two_letters_code%/%original_path%/%original_file_name%";
-        List<String> ignorePattern = Arrays.asList("**/.*");
+        String sourcePattern = Utils.normalizePath("/test/en/*.md");
+        String exportPattern = Utils.normalizePath("/test/%two_letters_code%/%original_path%/%original_file_name%");
+        List<String> ignorePatterns = Arrays.asList(Utils.normalizePath("**/.*"));
 
-        Map<String, File> obsoleteFiles = ObsoleteSourcesUtils.findObsoleteProjectFiles(projectFiles, preserveHierarchy,
-                filesToUpload, pattern, exportPattern, ignorePattern);
+        Map<String, File> obsoleteFiles = ObsoleteSourcesUtils.findObsoleteProjectFiles(projectFilesFromApi,
+                preserveHierarchy,
+                filesToUpload, sourcePattern, exportPattern, ignorePatterns);
 
         assertEquals(1, obsoleteFiles.size());
         assertEquals(true, obsoleteFiles.containsKey(Utils.normalizePath("test/en/support.md")));

--- a/src/test/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtilsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtilsTest.java
@@ -24,7 +24,8 @@ public class ObsoleteSourcesUtilsTest {
             }
         };
         boolean preserveHierarchy = true;
-        List<String> filesToUpload = Arrays.asList("test/en/test.md", "test/en/help.md");
+        List<String> filesToUpload = Arrays.asList(Utils.normalizePath("test/en/test.md"),
+                Utils.normalizePath("test/en/help.md"));
         String pattern = "/test/en/*.md";
         String exportPattern = "/test/%two_letters_code%/%original_path%/%original_file_name%";
         List<String> ignorePattern = Arrays.asList("**/.*");

--- a/src/test/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtilsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtilsTest.java
@@ -1,0 +1,37 @@
+package com.crowdin.cli.commands.functionality;
+
+import com.crowdin.cli.utils.Utils;
+import com.crowdin.client.sourcefiles.model.File;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ObsoleteSourcesUtilsTest {
+
+    @Test
+    public void testCreatePath_PathExists() {
+        Map<String, File> projectFiles = new HashMap<String, File>() {
+            {
+                put(Utils.normalizePath("test/en/test.md"), new File());
+                put(Utils.normalizePath("test/en/support.md"), new File());
+                put(Utils.normalizePath("test/en/help.md"), new File());
+            }
+        };
+        boolean preserveHierarchy = true;
+        List<String> filesToUpload = List.of("test/en/test.md", "test/en/help.md");
+        String pattern = "/test/en/*.md";
+        String exportPattern = "/test/%two_letters_code%/%original_path%/%original_file_name%";
+        List<String> ignorePattern = List.of("**/.*");
+
+        Map<String, File> obsoleteFiles = ObsoleteSourcesUtils.findObsoleteProjectFiles(projectFiles, preserveHierarchy,
+                filesToUpload, pattern, exportPattern, ignorePattern);
+
+        assertEquals(1, obsoleteFiles.size());
+    }
+
+}

--- a/src/test/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtilsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtilsTest.java
@@ -5,6 +5,7 @@ import com.crowdin.client.sourcefiles.model.File;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,10 +24,10 @@ public class ObsoleteSourcesUtilsTest {
             }
         };
         boolean preserveHierarchy = true;
-        List<String> filesToUpload = List.of("test/en/test.md", "test/en/help.md");
+        List<String> filesToUpload = Arrays.asList("test/en/test.md", "test/en/help.md");
         String pattern = "/test/en/*.md";
         String exportPattern = "/test/%two_letters_code%/%original_path%/%original_file_name%";
-        List<String> ignorePattern = List.of("**/.*");
+        List<String> ignorePattern = Arrays.asList("**/.*");
 
         Map<String, File> obsoleteFiles = ObsoleteSourcesUtils.findObsoleteProjectFiles(projectFiles, preserveHierarchy,
                 filesToUpload, pattern, exportPattern, ignorePattern);


### PR DESCRIPTION
closes #775 

Repro: https://github.com/anbraten/repro-crowdin-delete-obsolete

I am not sure why the `exportPattern` of a source-file was checked to see that it is obsolete. It works for me without the check, but I would also be happy to fix the check if it's needed and someone could explain me how it should work.