### PR TITLE
fix(aur): set & force java-environment=17

### DIFF
--- a/packages/aur/pkgbuild/PKGBUILD
+++ b/packages/aur/pkgbuild/PKGBUILD
@@ -6,8 +6,8 @@ pkgdesc="Command line tool that allows you to manage and synchronize localizatio
 url="https://support.crowdin.com/cli-tool/"
 license=('MIT')
 depends=('java-runtime>=17')
-makedepends=('git' 'java-environment>=17' 'grep' 'awk')
-conflicts=('crowdin-cli-bin')
+_jdkver=17
+makedepends=('git' "java-environment=$_jdkver" 'grep' 'awk')
 arch=('any')
 md5sums=('SKIP' 'b018bcf51df64a8e68450cd7ac0e3838')
 
@@ -18,15 +18,18 @@ source=(
 
 build() {
   cd "$srcdir/$pkgname"
+  # archlinux-java status doesn’t show whether it is a jdk or jre
+  # the user could have installed a jdk17 and a jre17 at the same time
+  # (eg. jdk17-openjdk and jre17 from AUR)
+  PATH=$(find /usr/lib/jvm/ -wholename "*$_jdkver*/javac" -print -quit | sed 's/javac//'):$PATH
   ./gradlew shadowJar
-  ./gradlew properties --no-daemon --console=plain -q | grep "^version:" | awk '{printf $2}' > _pkgBuildVersion
-  java -cp "build/libs/crowdin-cli-$(cat _pkgBuildVersion).jar" picocli.AutoComplete --force com.crowdin.cli.commands.picocli.RootCommand
+  java -cp "build/libs/crowdin-cli-$pkgver.jar" picocli.AutoComplete --force com.crowdin.cli.commands.picocli.RootCommand
 }
 
-package()
-{
-  cd "$srcdir"
-  install -Dm 0644 "$srcdir/$pkgname"/build/libs/crowdin-cli-$(cat "$srcdir/$pkgname"/_pkgBuildVersion).jar "$pkgdir"/usr/share/java/$pkgname/crowdin-cli.jar
-  install -Dm 0755 "$startdir"/crowdin "$pkgdir"/usr/bin/crowdin
-  install -Dm 0644 "$srcdir/$pkgname"/crowdin_completion "$pkgdir"/usr/share/bash-completion/completions/crowdin
+package() {
+  install -Dm 0755 crowdin "$pkgdir"/usr/bin/crowdin
+  cd "$srcdir/$pkgname"
+  install -Dm 0644 build/libs/crowdin-cli-$pkgver.jar "$pkgdir"/usr/share/java/$pkgname/crowdin-cli.jar
+  install -Dm 0644 crowdin_completion "$pkgdir"/usr/share/bash-completion/completions/crowdin
+  install -Dm 0644 LICENSE -t "$pkgdir"/usr/share/licenses/$pkgname/
 }


### PR DESCRIPTION
The currently used gradlew version does not support the latest java.
To fix this, specify java-environment=17 and put any jdk17 to the front
of PATH, in case a jdk17 is not currently selected by the user.

And:

- remove _pkgBuildVersion, use $pkgver
- install license

Closes: #847