### PR TITLE
fix: fixed usage of reserved "no" language code

### DIFF
--- a/src/main/java/com/crowdin/cli/properties/PropertiesBuilder.java
+++ b/src/main/java/com/crowdin/cli/properties/PropertiesBuilder.java
@@ -275,7 +275,7 @@ public abstract class PropertiesBuilder<T extends Properties, P extends Params> 
         }
     }
 
-    private static <T> T checkProperty(Map<String, Object> properties, String key, Class<T> clazz, T defaultValue) {
+    static <T> T checkProperty(Map<String, Object> properties, String key, Class<T> clazz, T defaultValue) {
         try {
            Object  param = properties.getOrDefault(key, defaultValue);
             if (param != null && !clazz.isAssignableFrom(param.getClass())) {

--- a/src/main/java/com/crowdin/cli/properties/PropertiesWithFiles.java
+++ b/src/main/java/com/crowdin/cli/properties/PropertiesWithFiles.java
@@ -2,19 +2,22 @@ package com.crowdin.cli.properties;
 
 import com.crowdin.cli.client.Clients;
 import com.crowdin.cli.client.ProjectClient;
+import com.crowdin.cli.utils.file.FileUtils;
 import com.crowdin.client.languages.model.Language;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.StringUtils;
+import org.yaml.snakeyaml.nodes.MappingNode;
+import org.yaml.snakeyaml.nodes.NodeTuple;
+import org.yaml.snakeyaml.nodes.ScalarNode;
+import org.yaml.snakeyaml.nodes.SequenceNode;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.crowdin.cli.BaseCli.IGNORE_HIDDEN_FILES_PATTERN;
 import static com.crowdin.cli.BaseCli.RESOURCE_BUNDLE;
-import static com.crowdin.cli.properties.PropertiesBuilder.FILES;
-import static com.crowdin.cli.properties.PropertiesBuilder.PRESERVE_HIERARCHY;
-import static com.crowdin.cli.properties.PropertiesBuilder.PSEUDO_LOCALIZATION;
+import static com.crowdin.cli.properties.PropertiesBuilder.*;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -35,10 +38,73 @@ public class PropertiesWithFiles extends ProjectProperties {
         @Override
         public void populateWithValues(PropertiesWithFiles props, Map<String, Object> map) {
             PropertiesBuilder.setBooleanPropertyIfExists(props::setPreserveHierarchy, map, PRESERVE_HIERARCHY);
-            props.setFiles(PropertiesBuilder.getListOfMaps(map, FILES)
-                .stream()
-                .map(FileBean.CONFIGURATOR::buildFromMap)
-                .collect(Collectors.toList()));
+            var ymlMeta = map.getOrDefault(FileUtils.YML_META, null);
+            //raw files node in yml
+            var filesMeta = Optional
+                    .ofNullable(ymlMeta)
+                    .filter(yml -> yml instanceof MappingNode)
+                    .map(MappingNode.class::cast)
+                    .map(MappingNode::getValue)
+                    .flatMap(values -> values.stream()
+                            .filter(v -> v.getKeyNode() instanceof ScalarNode)
+                            .filter(v -> ScalarNode.class.cast(v.getKeyNode()).getValue().equals(FILES))
+                            .map(NodeTuple::getValueNode)
+                            .filter(v -> v instanceof SequenceNode)
+                            .map(SequenceNode.class::cast)
+                            .map(SequenceNode::getValue)
+                            .findFirst()
+                    )
+                    .orElse(null);
+
+            List<FileBean> fileBeans = new ArrayList<>();
+            List<Map<String, Object>> listOfMaps = PropertiesBuilder.getListOfMaps(map, FILES);
+
+            for (int i = 0; i < listOfMaps.size(); i++) {
+                var fileMap = listOfMaps.get(i);
+                int finalI = i;
+                //raw languages node in yml
+                var languageMappingMeta = Optional.ofNullable(filesMeta)
+                        .filter(l -> l.size() > finalI)
+                        .map(l -> l.get(finalI))
+                        .filter(n -> n instanceof MappingNode)
+                        .map(MappingNode.class::cast)
+                        .map(MappingNode::getValue)
+                        .flatMap(values-> values.stream()
+                                .filter(v -> v.getKeyNode() instanceof ScalarNode)
+                                .filter(v -> ScalarNode.class.cast(v.getKeyNode()).getValue().equals(LANGUAGES_MAPPING))
+                                .map(NodeTuple::getValueNode)
+                                .filter(n -> n instanceof MappingNode)
+                                .map(MappingNode.class::cast)
+                                .map(MappingNode::getValue)
+                                .map(v -> {
+                                    Map<String, Map<String, String>> actualValues = new HashMap<>();
+                                    v.stream()
+                                            .filter(e -> e.getKeyNode() instanceof ScalarNode)
+                                            .filter(e -> e.getValueNode() instanceof MappingNode)
+                                            .forEach(e -> {
+                                                var key = ScalarNode.class.cast(e.getKeyNode()).getValue();
+                                                var val = MappingNode.class.cast(e.getValueNode());
+                                                Map<String, String> subMap = new HashMap<>();
+                                                val.getValue()
+                                                        .stream()
+                                                        .filter(e2 -> e2.getKeyNode() instanceof ScalarNode)
+                                                        .filter(e2 -> e2.getValueNode() instanceof ScalarNode)
+                                                        .forEach(e2 -> subMap.put(
+                                                                ScalarNode.class.cast(e2.getKeyNode()).getValue(),
+                                                                ScalarNode.class.cast(e2.getValueNode()).getValue()
+                                                        ));
+                                                actualValues.put(key, subMap);
+                                            });
+                                    return actualValues;
+                                })
+                                .findFirst()
+                        );
+                languageMappingMeta.ifPresent(meta -> fileMap.put(FileBean.LANGUAGES_META, meta));
+                var fileBean = FileBean.CONFIGURATOR.buildFromMap(fileMap);
+                fileBeans.add(fileBean);
+            }
+            props.setFiles(fileBeans);
+
             props.setPseudoLocalization(PseudoLocalization.CONFIGURATOR.buildFromMap(PropertiesBuilder.getMap(map, PSEUDO_LOCALIZATION)));
         }
 
@@ -86,8 +152,8 @@ public class PropertiesWithFiles extends ProjectProperties {
                             Set<String> langCodes = languages.stream().map(lang -> lang.getId().toLowerCase()).collect(Collectors.toSet());
 
                             boolean hasInvalidCode = fileBean.getLanguagesMapping().values().stream()
-                                .flatMap(innerMap -> innerMap.keySet().stream())
-                                .anyMatch(langCode -> !langCodes.contains(langCode.toLowerCase()));
+                                    .flatMap(innerMap -> innerMap.keySet().stream())
+                                    .anyMatch(langCode -> !langCodes.contains(langCode.toLowerCase()));
                             if (hasInvalidCode) {
                                 messages.addError(RESOURCE_BUNDLE.getString("error.config.languages_mapping"));
                             }

--- a/src/main/java/com/crowdin/cli/utils/file/FileUtils.java
+++ b/src/main/java/com/crowdin/cli/utils/file/FileUtils.java
@@ -2,13 +2,7 @@ package com.crowdin.cli.utils.file;
 
 import org.apache.commons.io.IOUtils;
 import org.yaml.snakeyaml.Yaml;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -22,6 +16,8 @@ public class FileUtils {
     private static final String YAML_EXTENSION = ".yaml";
     private static final String YML_EXTENSION = ".yml";
 
+    public static final String YML_META = "__yml__meta";
+
     public static Map<String, Object> readYamlFile(File fileCfg) {
         if (fileCfg == null) {
             throw new NullPointerException("FileReader.readCliConfig has null args");
@@ -31,8 +27,12 @@ public class FileUtils {
         }
 
         Yaml yaml = new Yaml();
-        try (InputStream inputStream = new FileInputStream(fileCfg)) {
-            return yaml.load(inputStream);
+
+        try {
+            var content = Files.readString(fileCfg.toPath());
+            Map<String, Object> map = yaml.load(content);
+            map.put(YML_META, yaml.compose(new StringReader(content)));
+            return map;
         } catch (FileNotFoundException e) {
             throw new RuntimeException(RESOURCE_BUNDLE.getString("error.configuration_file_not_exist"));
         } catch (Exception e) {


### PR DESCRIPTION
Unfortunately YAML has set of reserved words for boolean data type https://yaml.org/type/bool.html but since `no` is also a valid language code we need to bypass yml validation. 