### PR TITLE
fix: suppress progress output for crowdin file download with --no-progress

### DIFF
--- a/src/main/java/com/crowdin/cli/commands/Actions.java
+++ b/src/main/java/com/crowdin/cli/commands/Actions.java
@@ -140,11 +140,7 @@ public interface Actions {
 
     NewAction<ProjectProperties, ProjectClient> fileUploadTranslation(File file, String branch, String dest, String languageId, boolean plainView);
 
-    NewAction<ProjectProperties, ProjectClient> fileDownload(String file, String branch, String destParam);
-
     NewAction<ProjectProperties, ProjectClient> fileDownload(String file, String branch, boolean noProgress, String destParam);
-
-    NewAction<ProjectProperties, ProjectClient> fileDownloadTranslation(String file, String languageId, String branch, String destParam);
 
     NewAction<ProjectProperties, ProjectClient> fileDownloadTranslation(String file, String languageId, String branch, boolean noProgress, String destParam);
 

--- a/src/main/java/com/crowdin/cli/commands/Actions.java
+++ b/src/main/java/com/crowdin/cli/commands/Actions.java
@@ -142,7 +142,11 @@ public interface Actions {
 
     NewAction<ProjectProperties, ProjectClient> fileDownload(String file, String branch, String destParam);
 
+    NewAction<ProjectProperties, ProjectClient> fileDownload(String file, String branch, boolean noProgress, String destParam);
+
     NewAction<ProjectProperties, ProjectClient> fileDownloadTranslation(String file, String languageId, String branch, String destParam);
+
+    NewAction<ProjectProperties, ProjectClient> fileDownloadTranslation(String file, String languageId, String branch, boolean noProgress, String destParam);
 
     NewAction<ProjectProperties, ProjectClient> fileDelete(String file, String branch);
 

--- a/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
@@ -299,18 +299,8 @@ public class CliActions implements Actions {
     }
 
     @Override
-    public NewAction<ProjectProperties, ProjectClient> fileDownload(String file, String branch, String destParam) {
-        return new FileDownloadAction(file, branch, false, destParam);
-    }
-
-    @Override
     public NewAction<ProjectProperties, ProjectClient> fileDownload(String file, String branch, boolean noProgress, String destParam) {
         return new FileDownloadAction(file, branch, noProgress, destParam);
-    }
-
-    @Override
-    public NewAction<ProjectProperties, ProjectClient> fileDownloadTranslation(String file, String languageId, String branch, String destParam) {
-        return new FileDownloadTranslationAction(file, languageId, branch, false, destParam);
     }
 
     @Override

--- a/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
@@ -300,12 +300,22 @@ public class CliActions implements Actions {
 
     @Override
     public NewAction<ProjectProperties, ProjectClient> fileDownload(String file, String branch, String destParam) {
-        return new FileDownloadAction(file, branch, destParam);
+        return new FileDownloadAction(file, branch, false, destParam);
+    }
+
+    @Override
+    public NewAction<ProjectProperties, ProjectClient> fileDownload(String file, String branch, boolean noProgress, String destParam) {
+        return new FileDownloadAction(file, branch, noProgress, destParam);
     }
 
     @Override
     public NewAction<ProjectProperties, ProjectClient> fileDownloadTranslation(String file, String languageId, String branch, String destParam) {
-        return new FileDownloadTranslationAction(file, languageId, branch, destParam);
+        return new FileDownloadTranslationAction(file, languageId, branch, false, destParam);
+    }
+
+    @Override
+    public NewAction<ProjectProperties, ProjectClient> fileDownloadTranslation(String file, String languageId, String branch, boolean noProgress, String destParam) {
+        return new FileDownloadTranslationAction(file, languageId, branch, noProgress, destParam);
     }
 
     @Override

--- a/src/main/java/com/crowdin/cli/commands/actions/FileDownloadAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/FileDownloadAction.java
@@ -29,13 +29,14 @@ class FileDownloadAction implements NewAction<ProjectProperties, ProjectClient> 
 
     private final String file;
     private final String branch;
+    private final boolean noProgress;
     private final String dest;
 
     @Override
     public void act(Outputter out, ProjectProperties properties, ProjectClient client) {
         CrowdinProjectFull project = ConsoleSpinner
             .execute(out, "message.spinner.fetching_project_info", "error.collect_project_info",
-                false, false, () -> client.downloadFullProject(branch));
+                    noProgress, false, () -> client.downloadFullProject(branch));
         boolean isStringsBasedProject = Objects.equals(project.getType(), Type.STRINGS_BASED);
         if (isStringsBasedProject) {
             out.println(WARNING.withIcon(RESOURCE_BUNDLE.getString("message.no_file_string_project")));
@@ -56,7 +57,7 @@ class FileDownloadAction implements NewAction<ProjectProperties, ProjectClient> 
             out,
             "message.spinner.downloading_file",
             "error.downloading_file",
-            false,
+                noProgress,
             false,
             () -> {
                 URL url = client.downloadFile(foundFile.getId());

--- a/src/main/java/com/crowdin/cli/commands/actions/FileDownloadAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/FileDownloadAction.java
@@ -39,12 +39,11 @@ class FileDownloadAction implements NewAction<ProjectProperties, ProjectClient> 
         this.dest = dest;
     }
 
-
     @Override
     public void act(Outputter out, ProjectProperties properties, ProjectClient client) {
         CrowdinProjectFull project = ConsoleSpinner
             .execute(out, "message.spinner.fetching_project_info", "error.collect_project_info",
-                    noProgress, false, () -> client.downloadFullProject(branch));
+                noProgress, false, () -> client.downloadFullProject(branch));
         boolean isStringsBasedProject = Objects.equals(project.getType(), Type.STRINGS_BASED);
         if (isStringsBasedProject) {
             out.println(WARNING.withIcon(RESOURCE_BUNDLE.getString("message.no_file_string_project")));
@@ -65,7 +64,7 @@ class FileDownloadAction implements NewAction<ProjectProperties, ProjectClient> 
             out,
             "message.spinner.downloading_file",
             "error.downloading_file",
-                noProgress,
+            noProgress,
             false,
             () -> {
                 URL url = client.downloadFile(foundFile.getId());

--- a/src/main/java/com/crowdin/cli/commands/actions/FileDownloadAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/FileDownloadAction.java
@@ -32,6 +32,14 @@ class FileDownloadAction implements NewAction<ProjectProperties, ProjectClient> 
     private final boolean noProgress;
     private final String dest;
 
+    public FileDownloadAction(String file, String branch, String dest) {
+        this.file = file;
+        this.branch = branch;
+        this.noProgress = false;
+        this.dest = dest;
+    }
+
+
     @Override
     public void act(Outputter out, ProjectProperties properties, ProjectClient client) {
         CrowdinProjectFull project = ConsoleSpinner

--- a/src/main/java/com/crowdin/cli/commands/actions/FileDownloadTranslationAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/FileDownloadTranslationAction.java
@@ -43,7 +43,7 @@ public class FileDownloadTranslationAction implements NewAction<ProjectPropertie
     public void act(Outputter out, ProjectProperties properties, ProjectClient client) {
         CrowdinProjectFull project = ConsoleSpinner
             .execute(out, "message.spinner.fetching_project_info", "error.collect_project_info",
-                    noProgress, false, client::downloadFullProject);
+                noProgress, false, client::downloadFullProject);
         boolean isStringsBasedProject = Objects.equals(project.getType(), Type.STRINGS_BASED);
         if (isStringsBasedProject) {
             out.println(WARNING.withIcon(RESOURCE_BUNDLE.getString("message.no_file_string_project")));
@@ -83,7 +83,7 @@ public class FileDownloadTranslationAction implements NewAction<ProjectPropertie
                 out,
                 "message.spinner.building_translation",
                 "error.building_translation",
-                    noProgress,
+                noProgress,
                 false,
                 () -> client.buildProjectFileTranslation(sourceFileInfo.getId(), request)
             );
@@ -100,7 +100,7 @@ public class FileDownloadTranslationAction implements NewAction<ProjectPropertie
             out,
             "message.spinner.downloading_translation",
             "error.write_file",
-                noProgress,
+            noProgress,
             false,
             () -> {
                 FilesInterface files = new FsFiles();

--- a/src/main/java/com/crowdin/cli/commands/actions/FileDownloadTranslationAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/FileDownloadTranslationAction.java
@@ -36,13 +36,14 @@ public class FileDownloadTranslationAction implements NewAction<ProjectPropertie
     private final String file;
     private final String languageId;
     private final String branch;
+    private final boolean noProgress;
     private final String dest;
 
     @Override
     public void act(Outputter out, ProjectProperties properties, ProjectClient client) {
         CrowdinProjectFull project = ConsoleSpinner
             .execute(out, "message.spinner.fetching_project_info", "error.collect_project_info",
-                false, false, client::downloadFullProject);
+                    noProgress, false, client::downloadFullProject);
         boolean isStringsBasedProject = Objects.equals(project.getType(), Type.STRINGS_BASED);
         if (isStringsBasedProject) {
             out.println(WARNING.withIcon(RESOURCE_BUNDLE.getString("message.no_file_string_project")));
@@ -82,7 +83,7 @@ public class FileDownloadTranslationAction implements NewAction<ProjectPropertie
                 out,
                 "message.spinner.building_translation",
                 "error.building_translation",
-                false,
+                    noProgress,
                 false,
                 () -> client.buildProjectFileTranslation(sourceFileInfo.getId(), request)
             );
@@ -99,7 +100,7 @@ public class FileDownloadTranslationAction implements NewAction<ProjectPropertie
             out,
             "message.spinner.downloading_translation",
             "error.write_file",
-            false,
+                noProgress,
             false,
             () -> {
                 FilesInterface files = new FsFiles();

--- a/src/main/java/com/crowdin/cli/commands/picocli/FileDownloadSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/FileDownloadSubcommand.java
@@ -31,7 +31,7 @@ class FileDownloadSubcommand extends ActCommandProject {
     @Override
     protected NewAction<ProjectProperties, ProjectClient> getAction(Actions actions) {
         if (Objects.nonNull(languageId))
-            return actions.fileDownloadTranslation(file, languageId, branch, destination);
-        return actions.fileDownload(file, branch, destination);
+            return actions.fileDownloadTranslation(file, languageId, branch, noProgress, destination);
+        return actions.fileDownload(file, branch, noProgress, destination);
     }
 }

--- a/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
@@ -174,12 +174,12 @@ public class CliActionsTest {
 
     @Test
     void testFileDownload() {
-        assertNotNull(actions.fileDownload(null, null, null));
+        assertNotNull(actions.fileDownload(null, null, false, null));
     }
 
     @Test
     void testFileDownloadTranslation() {
-        assertNotNull(actions.fileDownloadTranslation(null, null,null, null));
+        assertNotNull(actions.fileDownloadTranslation(null, null,null, false,null));
     }
 
     @Test

--- a/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
@@ -179,7 +179,7 @@ public class CliActionsTest {
 
     @Test
     void testFileDownloadTranslation() {
-        assertNotNull(actions.fileDownloadTranslation(null, null,null, false,null));
+        assertNotNull(actions.fileDownloadTranslation(null, null,null, false, null));
     }
 
     @Test

--- a/src/test/java/com/crowdin/cli/commands/actions/FileDownloadActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/FileDownloadActionTest.java
@@ -54,7 +54,7 @@ class FileDownloadActionTest {
         when(client.downloadFile(eq(101L)))
             .thenReturn(urlMock);
 
-        NewAction<ProjectProperties, ProjectClient> action = new FileDownloadAction("first.po", null, "dest");
+        NewAction<ProjectProperties, ProjectClient> action = new FileDownloadAction("first.po", null, false,"dest");
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject(any());
@@ -75,7 +75,7 @@ class FileDownloadActionTest {
         when(client.downloadFullProject(any()))
             .thenReturn(build);
 
-        NewAction<ProjectProperties, ProjectClient> action = new FileDownloadAction("first.po", "main", "dest");
+        NewAction<ProjectProperties, ProjectClient> action = new FileDownloadAction("first.po", "main", false, "dest");
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject(any());

--- a/src/test/java/com/crowdin/cli/commands/actions/FileDownloadActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/FileDownloadActionTest.java
@@ -54,7 +54,7 @@ class FileDownloadActionTest {
         when(client.downloadFile(eq(101L)))
             .thenReturn(urlMock);
 
-        NewAction<ProjectProperties, ProjectClient> action = new FileDownloadAction("first.po", null, false,"dest");
+        NewAction<ProjectProperties, ProjectClient> action = new FileDownloadAction("first.po", null, false, "dest");
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject(any());

--- a/src/test/java/com/crowdin/cli/commands/actions/FileDownloadTranslationActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/FileDownloadTranslationActionTest.java
@@ -58,7 +58,7 @@ class FileDownloadTranslationActionTest {
         when(client.buildProjectFileTranslation(eq(101L), eq(request)))
             .thenReturn(urlMock);
 
-        NewAction<ProjectProperties, ProjectClient> action = new FileDownloadTranslationAction("first.po", "ua", null, null);
+        NewAction<ProjectProperties, ProjectClient> action = new FileDownloadTranslationAction("first.po", "ua", null, false, null);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -86,7 +86,7 @@ class FileDownloadTranslationActionTest {
         when(client.buildProjectFileTranslation(eq(101L), eq(request)))
             .thenReturn(urlMock);
 
-        NewAction<ProjectProperties, ProjectClient> action = new FileDownloadTranslationAction("first.po", "ua", null, "path/to/save");
+        NewAction<ProjectProperties, ProjectClient> action = new FileDownloadTranslationAction("first.po", "ua", null, false, "path/to/save");
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -108,7 +108,7 @@ class FileDownloadTranslationActionTest {
         when(client.downloadFullProject())
             .thenReturn(build);
 
-        NewAction<ProjectProperties, ProjectClient> action = new FileDownloadTranslationAction("first.po", "ua", null, "path/to/save");
+        NewAction<ProjectProperties, ProjectClient> action = new FileDownloadTranslationAction("first.po", "ua", null, false, "path/to/save");
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -137,7 +137,7 @@ class FileDownloadTranslationActionTest {
         when(client.buildProjectFileTranslation(eq(101L), any()))
             .thenReturn(urlMock);
 
-        NewAction<ProjectProperties, ProjectClient> action = new FileDownloadTranslationAction("first.po", "all", null, null);
+        NewAction<ProjectProperties, ProjectClient> action = new FileDownloadTranslationAction("first.po", "all", null, false, null);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();

--- a/src/test/java/com/crowdin/cli/commands/picocli/FileDownloadSubcommandTest.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/FileDownloadSubcommandTest.java
@@ -10,14 +10,14 @@ class FileDownloadSubcommandTest extends PicocliTestUtils {
     @Test
     public void testFileDownload() {
         this.execute(CommandNames.FILE, CommandNames.FILE_DOWNLOAD, "file.txt");
-        verify(actionsMock).fileDownload(any(), any(), any());
+        verify(actionsMock).fileDownload(any(), any(), false, any());
         this.check(true);
     }
 
     @Test
     public void testFileDownloadTranslations() {
         this.execute(CommandNames.FILE, CommandNames.FILE_DOWNLOAD, "file.txt", "--language", "uk");
-        verify(actionsMock).fileDownloadTranslation(any(), any(), any(), any());
+        verify(actionsMock).fileDownloadTranslation(any(), any(), any(), false, any());
         this.check(true);
     }
 

--- a/src/test/java/com/crowdin/cli/commands/picocli/PicocliTestUtils.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/PicocliTestUtils.java
@@ -124,9 +124,9 @@ public class PicocliTestUtils {
                 .thenReturn(actionMock);
         when(actionsMock.fileUploadTranslation(any(), any(), any(), any(), anyBoolean()))
                 .thenReturn(actionMock);
-        when(actionsMock.fileDownload(any(), any(), any()))
+        when(actionsMock.fileDownload(any(), any(), anyBoolean(), any()))
                 .thenReturn(actionMock);
-        when(actionsMock.fileDownloadTranslation(any(), any(), any(), any()))
+        when(actionsMock.fileDownloadTranslation(any(), any(), any(), anyBoolean(), any()))
                 .thenReturn(actionMock);
         when(actionsMock.fileDelete(any(), any()))
                 .thenReturn(actionMock);


### PR DESCRIPTION
## Changes made
- Added `noProgress` parameter: Allows disabling the progress display during the download process.
- **Backward Compatibility**: Existing method calls remain functional as overloaded methods with default `noProgress = false` are provided.

## How to test 
To run the CLI application with the following arguments:
1. To test `FileDownload`
```
file download locale/en.json -d ./example --no-progress
```
2. To test `FileDownloadTranslation`
```
file download locale/en.json -l en -d ./example --no-progress
```

This closes #878 