### PR TITLE
chore: remove unused dependencies from installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,7 @@
   },
   "dependencies": {
     "command-exists-promise": "^2.0.2",
-    "node-fetch": "2.7.0",
-    "shelljs": "^0.8.5",
-    "tar": "^7.4.3",
-    "yauzl": "^3.2.0"
+    "node-fetch": "2.7.0"
   },
   "license": "MIT",
   "files": [
@@ -43,10 +40,10 @@
     "Translation management"
   ],
   "devDependencies": {
-    "semantic-release-replace-plugin": "^1.2.7",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^7.0.3",
     "@semantic-release/git": "^10.0.1",
-    "semantic-release": "^24.2.1"
+    "semantic-release": "^24.2.1",
+    "semantic-release-replace-plugin": "^1.2.7"
   }
 }


### PR DESCRIPTION
Noticed that there was a large dependency tree off of the npm crowdin-cli while looking at a project that uses the crowdin-cli tool.

Taking a look at this, we started off with 61 total dependencies that were required and ended up afterwards going down to 5 total dependencies.  Overall yauzl, tar, and shelljs were contributing the most required packages.  Running tests seemed to indicate that these packages were not needed anymore and I could find no usage of these packages throughout the codebase.