### PR TITLE
fix: file update for soft match

### DIFF
--- a/src/main/java/com/crowdin/cli/commands/actions/FileUploadAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/FileUploadAction.java
@@ -83,7 +83,7 @@ class FileUploadAction implements NewAction<ProjectProperties, ProjectClient> {
             fileFullPath = (nonNull(branchName) ? branchName + Utils.PATH_SEPARATOR : "") + filePath;
             fileDestName = fileFullPath.substring(fileFullPath.lastIndexOf(Utils.PATH_SEPARATOR) + 1);
             Map<String, FileInfo> paths = ProjectFilesUtils.buildFilePaths(project.getDirectories(), project.getBranches(), project.getFileInfos());
-            FileInfo projectFile = ProjectFilesUtils.fileLookup(fileFullPath, paths);
+            Map.Entry<FileInfo, Boolean> projectFile = ProjectFilesUtils.fileLookup(fileFullPath, paths);
 
             if (nonNull(projectFile)) {
                 if (!autoUpdate) {
@@ -91,7 +91,7 @@ class FileUploadAction implements NewAction<ProjectProperties, ProjectClient> {
                     return;
                 }
                 final UpdateFileRequest request = new UpdateFileRequest();
-                final Long sourceId = projectFile.getId();
+                final Long sourceId = projectFile.getKey().getId();
                 attachLabelIds.ifPresent(request::setAttachLabelIds);
 
                 Long storageId = getStorageId(client, fileDestName);
@@ -100,7 +100,7 @@ class FileUploadAction implements NewAction<ProjectProperties, ProjectClient> {
                 try {
                     client.updateSource(sourceId, request);
                     if (nonNull(excludedLanguages) && !excludedLanguages.isEmpty()) {
-                        List<String> projectFileExcludedTargetLanguages = ((com.crowdin.client.sourcefiles.model.File) projectFile).getExcludedTargetLanguages();
+                        List<String> projectFileExcludedTargetLanguages = ((com.crowdin.client.sourcefiles.model.File) projectFile.getKey()).getExcludedTargetLanguages();
                         if (!Objects.equals(excludedLanguages, projectFileExcludedTargetLanguages)) {
                             List<PatchRequest> editRequest = RequestBuilder.updateExcludedTargetLanguages(excludedLanguages);
                             client.editSource(sourceId, editRequest);

--- a/src/main/java/com/crowdin/cli/commands/actions/UploadSourcesAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/UploadSourcesAction.java
@@ -195,7 +195,7 @@ class UploadSourcesAction implements NewAction<PropertiesWithFiles, ProjectClien
                             final UpdateFileRequest request = new UpdateFileRequest();
                             if (!projectFile.getValue()) {
                                 //only for soft match we set name
-                                request.setName(projectFile.getKey().getName());
+                                request.setName(source.substring(source.lastIndexOf(Utils.PATH_SEPARATOR) + 1));
                             }
                             request.setExportOptions(buildExportOptions(sourceFile, file, pb.getBasePath()));
                             request.setImportOptions(buildImportOptions(sourceFile, file, srxStorageId));

--- a/src/main/java/com/crowdin/cli/commands/actions/UploadTranslationsAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/UploadTranslationsAction.java
@@ -122,7 +122,7 @@ class UploadTranslationsAction implements NewAction<PropertiesWithFiles, Project
                         }
                         return;
                     }
-                    Long fileId = sourceFile.getId();
+                    Long fileId = sourceFile.getKey().getId();
 
 //                build filePath to each source and project language
                     String fileSource = StringUtils.removeStart(source, pb.getBasePath());

--- a/src/main/java/com/crowdin/cli/commands/functionality/ProjectFilesUtils.java
+++ b/src/main/java/com/crowdin/cli/commands/functionality/ProjectFilesUtils.java
@@ -12,11 +12,7 @@ import com.crowdin.client.sourcefiles.model.GeneralFileExportOptions;
 import com.crowdin.client.sourcefiles.model.PropertyFileExportOptions;
 import lombok.NonNull;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -35,23 +31,27 @@ public class ProjectFilesUtils {
         return filePathsToId;
     }
 
-    public static <T> T fileLookup(String filePath, Map<String, T> files) {
+    public static <T> Map.Entry<T, Boolean> fileLookup(String filePath, Map<String, T> files) {
         if (files.containsKey(filePath)) {
-            return files.get(filePath);
+            return new AbstractMap.SimpleEntry<>(files.get(filePath), true);
         }
 
         T fallback = null;
 
         for (var entry : files.entrySet()) {
             if (ProjectFilesUtils.equalsIgnoreExtension(filePath, entry.getKey())) {
-                return entry.getValue();
+                return new AbstractMap.SimpleEntry<>(entry.getValue(), false);
             } else if (ProjectFilesUtils.equalsIgnoreExtraExtension(filePath, entry.getKey())) {
                 //storing it as a fallback because perfect match should have higher priority
                 fallback = entry.getValue();
             }
         }
 
-        return fallback;
+        if (fallback == null) {
+            return null;
+        }
+
+        return new AbstractMap.SimpleEntry<>(fallback, false);
     }
 
     public static boolean equalsIgnoreExtension(String file1, String file2) {

--- a/src/test/java/com/crowdin/cli/commands/functionality/ProjectFilesUtilsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/functionality/ProjectFilesUtilsTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -84,9 +85,9 @@ public class ProjectFilesUtilsTest {
         String file4 = "path/to/file.json";
         String file5 = "path/to/file.json.xml";
 
-        assertEquals(file1, ProjectFilesUtils.fileLookup(file1, Map.of(file1, file1, file2, file2)));
-        assertEquals(file2, ProjectFilesUtils.fileLookup(file1, Map.of(file2, file2, file3, file3)));
-        assertEquals(file4, ProjectFilesUtils.fileLookup(file4, Map.of(file5, file4)));
+        assertEquals(new AbstractMap.SimpleEntry<>(file1, true), ProjectFilesUtils.fileLookup(file1, Map.of(file1, file1, file2, file2)));
+        assertEquals(new AbstractMap.SimpleEntry<>(file2, false), ProjectFilesUtils.fileLookup(file1, Map.of(file2, file2, file3, file3)));
+        assertEquals(new AbstractMap.SimpleEntry<>(file4, false), ProjectFilesUtils.fileLookup(file4, Map.of(file5, file4)));
         assertNull(ProjectFilesUtils.fileLookup(file3, Map.of(file1, file1, file2, file2)));
         assertNull(ProjectFilesUtils.fileLookup("path/to/test", Map.of(file1, file1, file2, file2)));
     }

--- a/versions.properties
+++ b/versions.properties
@@ -43,7 +43,7 @@ version.commons-io..commons-io=2.16.1
 
 version.commons-cli..commons-cli=1.7.0
 
-version.com.github.crowdin..crowdin-api-client-java=1.27.4
+version.com.github.crowdin..crowdin-api-client-java=1.27.5
 
 plugin.org.asciidoctor.jvm.convert=3.3.2
 


### PR DESCRIPTION
Adding `name` to update file request only if it's a "soft" match (ignoring extensions change)