### PR TITLE
fix(pre-translate): align parameter validations with API

### DIFF
--- a/src/main/java/com/crowdin/cli/commands/picocli/PreTranslateSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/PreTranslateSubcommand.java
@@ -105,7 +105,7 @@ public class PreTranslateSubcommand extends ActCommandWithFiles {
         if ((Method.MT == method) && (engineId == null)) {
             errors.add(RESOURCE_BUNDLE.getString("error.pre_translate.engine_id"));
         }
-        if ((Method.MT == method || Method.AI == method) && translateWithPerfectMatchOnly != null) {
+        if ((Method.TM != method) && translateWithPerfectMatchOnly != null) {
             errors.add(RESOURCE_BUNDLE.getString("error.pre_translate.translate_with_perfect_match_only"));
         }
         if (Method.MT == method && autoApproveOption != null) {

--- a/src/main/java/com/crowdin/cli/commands/picocli/PreTranslateSubcommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/PreTranslateSubcommand.java
@@ -105,13 +105,7 @@ public class PreTranslateSubcommand extends ActCommandWithFiles {
         if ((Method.MT == method) && (engineId == null)) {
             errors.add(RESOURCE_BUNDLE.getString("error.pre_translate.engine_id"));
         }
-        if ((Method.MT == method) && duplicateTranslations != null) {
-            errors.add(RESOURCE_BUNDLE.getString("error.pre_translate.duplicate_translations"));
-        }
-        if ((Method.MT == method) && translateUntranslatedOnly != null) {
-            errors.add(RESOURCE_BUNDLE.getString("error.pre_translate.translate_untranslated_only"));
-        }
-        if ((Method.MT == method) && translateWithPerfectMatchOnly != null) {
+        if ((Method.MT == method || Method.AI == method) && translateWithPerfectMatchOnly != null) {
             errors.add(RESOURCE_BUNDLE.getString("error.pre_translate.translate_with_perfect_match_only"));
         }
         if (Method.MT == method && autoApproveOption != null) {

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -639,8 +639,6 @@ error.distribution.not_found=Couldn't find distribution with the specified hash 
 error.pre_translate.directory_or_file_only=Either '--file' or '--directory' can be specified
 error.pre_translate.engine_id=Machine Translation should be used with the '--engine-id' parameter
 error.pre_translate.ai_prompt=AI should be used with the '--ai-prompt' parameter
-error.pre_translate.duplicate_translations='--duplicate-translations' only works with the TM pre-translation method
-error.pre_translate.translate_untranslated_only='--translate-untranslated-only' only works with the TM pre-translation method
 error.pre_translate.translate_with_perfect_match_only='--translate-with-perfect-match-only' only works with the TM pre-translation method
 error.pre_translate.auto_approve_option=Wrong '--auto-approve-option' parameter. Supported values: all, except-auto-substituted, perfect-match-only, none
 


### PR DESCRIPTION
Remove client-side validations for parameters that can now be used with any pre-translation method (duplicateTranslations, translateUntranslatedOnly).

Keep validation for translateWithPerfectMatchOnly as it remains TM-only per API documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Loosens pre-translate option checks to allow `duplicateTranslations` and `translateUntranslatedOnly` for all methods, while keeping `translateWithPerfectMatchOnly` TM-only and removing obsolete error messages.
> 
> - **Pre-translate validations**:
>   - Allow `--duplicate-translations` and `--translate-untranslated-only` with any `method` by removing MT-specific restrictions in `PreTranslateSubcommand#checkOptions`.
>   - Enforce `--translate-with-perfect-match-only` only for TM by validating `method != TM` → error.
> - **Messages**:
>   - Remove unused errors `error.pre_translate.duplicate_translations` and `error.pre_translate.translate_untranslated_only` from `messages.properties`.
>   - Keep `error.pre_translate.translate_with_perfect_match_only` and other existing messages unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4be2a125069df6a257157f7e443aaeef0eb4169d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->