### PR TITLE
feat: upload sources with cache

### DIFF
--- a/src/main/java/com/crowdin/cli/commands/Actions.java
+++ b/src/main/java/com/crowdin/cli/commands/Actions.java
@@ -62,7 +62,7 @@ public interface Actions {
         boolean noProgress, boolean isVerbose, String file, String filter, String branchName, List<String> labelNames, String croql, String directory, String scope, boolean plainView);
 
     NewAction<PropertiesWithFiles, ProjectClient> uploadSources(
-        String branchName, boolean deleteObsolete, boolean noProgress, boolean autoUpdate, boolean debug, boolean plainView);
+        String branchName, boolean deleteObsolete, boolean noProgress, boolean autoUpdate, boolean debug, boolean plainView, boolean cache);
 
     NewAction<PropertiesWithFiles, ProjectClient> uploadTranslations(
         boolean noProgress, String languageId, String branchName, boolean importEqSuggestions,

--- a/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/CliActions.java
@@ -112,9 +112,9 @@ public class CliActions implements Actions {
 
     @Override
     public NewAction<PropertiesWithFiles, ProjectClient> uploadSources(
-        String branchName, boolean deleteObsolete, boolean noProgress, boolean autoUpdate, boolean debug, boolean plainView
+        String branchName, boolean deleteObsolete, boolean noProgress, boolean autoUpdate, boolean debug, boolean plainView, boolean cache
     ) {
-        return new UploadSourcesAction(branchName, deleteObsolete, noProgress, autoUpdate, debug, plainView);
+        return new UploadSourcesAction(branchName, deleteObsolete, noProgress, autoUpdate, debug, plainView, cache);
     }
 
     @Override

--- a/src/main/java/com/crowdin/cli/commands/actions/UploadSourcesAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/UploadSourcesAction.java
@@ -45,14 +45,16 @@ class UploadSourcesAction implements NewAction<PropertiesWithFiles, ProjectClien
     private boolean autoUpdate;
     private boolean debug;
     private boolean plainView;
+    private boolean cache;
 
-    public UploadSourcesAction(String branchName, boolean deleteObsolete, boolean noProgress, boolean autoUpdate, boolean debug, boolean plainView) {
+    public UploadSourcesAction(String branchName, boolean deleteObsolete, boolean noProgress, boolean autoUpdate, boolean debug, boolean plainView, boolean cache) {
         this.branchName = branchName;
         this.deleteObsolete = deleteObsolete;
         this.noProgress = noProgress || plainView;
         this.autoUpdate = autoUpdate;
         this.debug = debug;
         this.plainView = plainView;
+        this.cache = cache;
     }
 
     @Override

--- a/src/main/java/com/crowdin/cli/commands/actions/UploadSourcesAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/UploadSourcesAction.java
@@ -201,9 +201,7 @@ class UploadSourcesAction implements NewAction<PropertiesWithFiles, ProjectClien
                                     return false;
                                 }
                             } catch (Exception e) {
-                                if (plainView) {
-                                    OutputUtil.fancyErr(e, System.err, debug);
-                                }
+                                OutputUtil.fancyErr(e, System.err, debug);
                                 return true;
                             }
                         }
@@ -275,9 +273,7 @@ class UploadSourcesAction implements NewAction<PropertiesWithFiles, ProjectClien
                                             String currentHash = FileUtils.computeChecksum(sourceFile.toPath());
                                             sourceHashes.put(source, currentHash);
                                         } catch (Exception e) {
-                                            if (plainView) {
-                                                OutputUtil.fancyErr(e, System.err, debug);
-                                            }
+                                            OutputUtil.fancyErr(e, System.err, debug);
                                         }
                                     }
                                 } catch (FileInUpdateException e) {
@@ -365,9 +361,7 @@ class UploadSourcesAction implements NewAction<PropertiesWithFiles, ProjectClien
                                         String currentHash = FileUtils.computeChecksum(sourceFile.toPath());
                                         sourceHashes.put(source, currentHash);
                                     } catch (Exception e) {
-                                        if (plainView) {
-                                            OutputUtil.fancyErr(e, System.err, debug);
-                                        }
+                                        OutputUtil.fancyErr(e, System.err, debug);
                                     }
                                 }
                             };
@@ -441,9 +435,7 @@ class UploadSourcesAction implements NewAction<PropertiesWithFiles, ProjectClien
                                         String currentHash = FileUtils.computeChecksum(sourceFile.toPath());
                                         sourceHashes.put(source, currentHash);
                                     } catch (Exception e) {
-                                        if (plainView) {
-                                            OutputUtil.fancyErr(e, System.err, debug);
-                                        }
+                                        OutputUtil.fancyErr(e, System.err, debug);
                                     }
                                 }
                             };

--- a/src/main/java/com/crowdin/cli/commands/picocli/UploadSourcesCommand.java
+++ b/src/main/java/com/crowdin/cli/commands/picocli/UploadSourcesCommand.java
@@ -38,11 +38,14 @@ class UploadSourcesCommand extends ActCommandWithFiles {
     @CommandLine.Option(names = {"--plain"}, descriptionKey = "crowdin.list.usage.plain")
     protected boolean plainView;
 
+    @CommandLine.Option(names = {"--cache"}, descriptionKey = "crowdin.upload.sources.cache")
+    protected boolean cache;
+
     @Override
     protected NewAction<PropertiesWithFiles, ProjectClient> getAction(Actions actions) {
         return (dryrun)
             ? actions.listSources(this.deleteObsolete, this.branch, this.noProgress, this.treeView, plainView)
-            : actions.uploadSources(this.branch, this.deleteObsolete, this.noProgress, this.autoUpdate, debug, plainView);
+            : actions.uploadSources(this.branch, this.deleteObsolete, this.noProgress, this.autoUpdate, debug, plainView, cache);
     }
 
     @Override

--- a/src/main/java/com/crowdin/cli/utils/cache/Cache.java
+++ b/src/main/java/com/crowdin/cli/utils/cache/Cache.java
@@ -1,0 +1,65 @@
+package com.crowdin.cli.utils.cache;
+
+import com.crowdin.cli.commands.Outputter;
+import com.crowdin.cli.utils.Utils;
+import org.json.JSONObject;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.crowdin.cli.BaseCli.RESOURCE_BUNDLE;
+import static com.crowdin.cli.utils.console.ExecutionStatus.ERROR;
+
+public class Cache {
+
+    private static final String CACHE_LOCATION = System.getProperty("user.home") + Utils.PATH_SEPARATOR + ".crowdin" + Utils.PATH_SEPARATOR + "cache.json";
+
+    private static JSONObject CACHE = new JSONObject();
+
+    public static void initialize(boolean plainView, Outputter out) {
+        try {
+            if (!Files.exists(Paths.get(CACHE_LOCATION))) {
+                return;
+            }
+
+            String json = String.join("", Files.readAllLines(Paths.get(CACHE_LOCATION)));
+
+            CACHE = new JSONObject(json);
+        } catch (Exception e) {
+            if (!plainView) {
+                out.println(ERROR.withIcon(RESOURCE_BUNDLE.getString("error.cache_init")));
+            } else {
+                out.println(RESOURCE_BUNDLE.getString("error.cache_init"));
+            }
+        }
+    }
+
+    public static void save(boolean plainView, Outputter out) {
+        try {
+            Files.createDirectories(Paths.get(CACHE_LOCATION).getParent());
+            Files.write(Paths.get(CACHE_LOCATION), CACHE.toString(4).getBytes());
+        } catch (Exception e) {
+            if (!plainView) {
+                out.println(ERROR.withIcon(RESOURCE_BUNDLE.getString("error.cache_save")));
+            } else {
+                out.println(RESOURCE_BUNDLE.getString("error.cache_save"));
+            }
+        }
+    }
+
+    public static Map<String, String> getSourceHashes() {
+        if (!CACHE.has("sourceHashes")) {
+            CACHE.put("sourceHashes", new HashMap<>());
+        }
+        JSONObject obj = CACHE.getJSONObject("sourceHashes");
+        return obj.toMap().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
+    }
+
+    public static void setSourceHashes(Map<String, String> sourceHashes) {
+        CACHE.put("sourceHashes", sourceHashes);
+    }
+}

--- a/src/main/java/com/crowdin/cli/utils/file/FileUtils.java
+++ b/src/main/java/com/crowdin/cli/utils/file/FileUtils.java
@@ -3,15 +3,13 @@ package com.crowdin.cli.utils.file;
 import org.apache.commons.io.IOUtils;
 import org.yaml.snakeyaml.Yaml;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 
 import static com.crowdin.cli.BaseCli.RESOURCE_BUNDLE;
@@ -49,5 +47,20 @@ public class FileUtils {
         IOUtils.copy(data, fileOutputStream);
         fileOutputStream.flush();
         fileOutputStream.close();
+    }
+
+    public static String computeChecksum(Path path) throws IOException, NoSuchAlgorithmException {
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        try (InputStream is = Files.newInputStream(path);
+             DigestInputStream dis = new DigestInputStream(is, md)) {
+            byte[] buffer = new byte[8192];
+            while (dis.read(buffer) != -1) { /* read to update digest */ }
+        }
+        byte[] digest = md.digest();
+        StringBuilder sb = new StringBuilder(digest.length * 2);
+        for (byte b : digest) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
     }
 }

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -87,6 +87,7 @@ crowdin.upload.sources.usage.description=Upload source files to a Crowdin projec
 crowdin.upload.sources.usage.customSynopsis=@|fg(green) crowdin |@(@|fg(green) upload|@|@|fg(green) push|@) @|fg(green) sources|@ [CONFIG OPTIONS] [OPTIONS]
 crowdin.upload.sources.no-auto-update=Specify whether to update existing source files in the Crowdin project or only upload new ones. Updates by default
 crowdin.upload.sources.delete-obsolete=Delete obsolete files and folders from the Crowdin project that no longer match the source configuration or have been deleted locally
+crowdin.upload.sources.cache=Use local cache to determine changed files and upload only them
 
 # CROWDIN UPLOAD COMMAND
 crowdin.upload.usage.description=Upload source files to a Crowdin project

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -719,6 +719,7 @@ message.new_version_text.2=Changelog: @|cyan https://github.com/crowdin/crowdin-
 message.new_version_text.3=Please update for the best experience!
 message.uploading_file=@|green File '%s'|@
 message.uploading_file_skipped=File '%s' was skipped since it is empty
+message.uploading_file_skipped_cached=File '%s' was skipped since it is up to date
 message.file_being_updated=File '%s' is currently being updated
 message.downloaded_file=@|green File '%s'|@
 message.file_path=%s

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -579,6 +579,8 @@ error.duplicate_environment_variable=There might be a duplicate environment vari
 error.no_files_found_for_pre_translate=Couldn't find any files to Pre-Translate in the current project
 error.project_is_incomplete=The current project is incomplete
 error.string_based_only=This command is only available for string-based projects
+error.cache_init=Failed to initialize cache
+error.cache_save=Failed to save cache
 
 error.glossary.build_glossary=Failed to build the glossary
 error.glossary.wrong_format=Supported formats: tbx, csv, xlsx

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -87,7 +87,7 @@ crowdin.upload.sources.usage.description=Upload source files to a Crowdin projec
 crowdin.upload.sources.usage.customSynopsis=@|fg(green) crowdin |@(@|fg(green) upload|@|@|fg(green) push|@) @|fg(green) sources|@ [CONFIG OPTIONS] [OPTIONS]
 crowdin.upload.sources.no-auto-update=Specify whether to update existing source files in the Crowdin project or only upload new ones. Updates by default
 crowdin.upload.sources.delete-obsolete=Delete obsolete files and folders from the Crowdin project that no longer match the source configuration or have been deleted locally
-crowdin.upload.sources.cache=Use local cache to determine changed files and upload only them
+crowdin.upload.sources.cache=Use local cache to determine changed files and upload only them (experimental)
 
 # CROWDIN UPLOAD COMMAND
 crowdin.upload.usage.description=Upload source files to a Crowdin project

--- a/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/CliActionsTest.java
@@ -69,7 +69,7 @@ public class CliActionsTest {
 
     @Test
     public void testUploadSources() {
-        assertNotNull(actions.uploadSources(null, false, false, false, false, false));
+        assertNotNull(actions.uploadSources(null, false, false, false, false, false, false));
     }
 
     @Test

--- a/src/test/java/com/crowdin/cli/commands/actions/UploadSourcesActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/UploadSourcesActionTest.java
@@ -73,7 +73,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.po"), any()))
             .thenReturn(1L);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -112,7 +112,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.po"), any()))
                 .thenReturn(1L);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -151,7 +151,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.properties"), any()))
           .thenReturn(1L);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -192,7 +192,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.js"), any()))
           .thenReturn(1L);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -243,7 +243,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("third.po"), any()))
             .thenReturn(3L);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -318,7 +318,7 @@ public class UploadSourcesActionTest {
         when(client.addBranch(addBranchRequest))
             .thenReturn(branch);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction("newBranch", false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction("newBranch", false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -358,7 +358,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.po"), any()))
             .thenReturn(1L);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction("newBranch", false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction("newBranch", false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -396,7 +396,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.po"), any()))
             .thenReturn(1L);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -436,7 +436,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.po"), any()))
             .thenReturn(1L);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -475,7 +475,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.po"), any()))
             .thenReturn(1L);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -524,7 +524,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("/docs/en/index.md"), any()))
                 .thenReturn(1L);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, true, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, true, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -571,7 +571,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("/docs/en/index+new.md"), any()))
             .thenReturn(1L);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, true, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, true, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -612,7 +612,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("second.po"), any()))
             .thenReturn(2L);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -664,7 +664,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.csv"), any()))
                 .thenReturn(1L);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -710,7 +710,7 @@ public class UploadSourcesActionTest {
         when(client.uploadStorage(eq("first.po"), any()))
             .thenReturn(1L);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -756,7 +756,7 @@ public class UploadSourcesActionTest {
                 setId(3L);
             }});
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, true, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, true, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -811,7 +811,7 @@ public class UploadSourcesActionTest {
                 setId(4L);
             }});
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction(null, false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();
@@ -861,7 +861,7 @@ public class UploadSourcesActionTest {
             .thenReturn(1L);
         when(client.addSourceStringsBased(eq(uploadStringsRequest))).thenReturn(uploadStringsProgress);
 
-        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction("main", false, false, true, false, false);
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadSourcesAction("main", false, false, true, false, false, false);
         action.act(Outputter.getDefault(), pb, client);
 
         verify(client).downloadFullProject();

--- a/src/test/java/com/crowdin/cli/commands/picocli/PicocliTestUtils.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/PicocliTestUtils.java
@@ -78,7 +78,7 @@ public class PicocliTestUtils {
             .thenReturn(actionMock);
         when(actionsMock.stringList(anyBoolean(), anyBoolean(), any(), any(), any(), any(), any(), any(), any(), anyBoolean()))
             .thenReturn(actionMock);
-        when(actionsMock.uploadSources(any(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean()))
+        when(actionsMock.uploadSources(any(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean()))
             .thenReturn(actionMock);
         when(actionsMock.uploadTranslations(anyBoolean(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean()))
             .thenReturn(actionMock);

--- a/src/test/java/com/crowdin/cli/commands/picocli/UploadSourcesCommandTest.java
+++ b/src/test/java/com/crowdin/cli/commands/picocli/UploadSourcesCommandTest.java
@@ -12,7 +12,7 @@ public class UploadSourcesCommandTest extends PicocliTestUtils {
     public void testUploadSources() {
         this.execute(CommandNames.UPLOAD);
         verify(actionsMock)
-            .uploadSources(any(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            .uploadSources(any(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
         this.check(true);
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an optional --cache mode to source uploads that skips unchanged files using persisted SHA-256 checksums.
> 
> - **CLI / Commands**:
>   - Add `--cache` option to `upload sources` (`UploadSourcesCommand`) and plumb through `Actions.uploadSources` and `CliActions`.
> - **Upload Logic**:
>   - Extend `UploadSourcesAction` to support caching: compute file checksums, skip unchanged sources with a "skipped cached" message, and persist updated hashes.
>   - Introduce `FileUtils.computeChecksum` (SHA-256) and new `utils/cache/Cache` for reading/writing `~/.crowdin/cache.json`.
> - **Messages**:
>   - Add messages for cache init/save errors and cached-skip notice.
> - **Tests**:
>   - Update tests to new method signatures and verify `uploadSources` is called with the cache flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7720fe0de02ed9154c1c9e01e1a9b350f0f0474. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->