### PR TITLE
feat: add source file existence validation to config lint

### DIFF
--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -685,6 +685,7 @@ error.config.base_path_not_exist=The base path %s was not found. Check your 'bas
 error.config.base_path_empty='base_path' in your configuration file is empty. Specify your 'base_path' and try again
 error.config.empty_or_missed_section_files=Required section 'files' is missing (or empty) in the configuration file
 error.config.empty_source_section=The 'source' parameter can't be empty. Specify the source paths in your configuration file
+error.config.source_not_found=No source files found for '%s' pattern. Verify the path exists and matches files in your project
 error.config.empty_translation_section=The 'translation' parameter can't be empty. Specify the translation paths in your configuration file
 error.config.double_asterisk=The mask '**' can be used in the 'translation' pattern only if it's used in the 'source' pattern
 error.config.translation_has_no_language_placeholders=The 'translation' parameter should contain at least one language placeholder (e.g. %locale%)

--- a/src/test/java/com/crowdin/cli/properties/PropertiesWithFilesTest.java
+++ b/src/test/java/com/crowdin/cli/properties/PropertiesWithFilesTest.java
@@ -1,16 +1,32 @@
 package com.crowdin.cli.properties;
 
 import com.crowdin.cli.commands.Outputter;
+import com.crowdin.cli.properties.helper.TempProject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static com.crowdin.cli.properties.PropertiesConfigurator.CheckType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PropertiesWithFilesTest {
 
     private final Outputter out = Outputter.getDefault();
+    private TempProject tempProject;
 
     NewPropertiesWithFilesUtilBuilder pbBuilder = NewPropertiesWithFilesUtilBuilder.minimalBuiltPropertiesBean();
+
+    @BeforeEach
+    public void setUp() {
+        tempProject = new TempProject(PropertiesWithFilesTest.class);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        tempProject.delete();
+    }
 
     @Test
     public void rightParams_populateWithPreserveHierarchyArg() {
@@ -29,5 +45,78 @@ public class PropertiesWithFilesTest {
 
         new PropertiesWithFilesBuilder(out).populateWithArgParams(props, params);
         assertFalse(props.getPreserveHierarchy());
+    }
+
+    @Test
+    public void testCheckProperties_sourceFileExists_noError() {
+        tempProject.addFile("test.txt", "content");
+
+        PropertiesWithFiles props = NewPropertiesWithFilesUtilBuilder
+            .minimalBuiltPropertiesBean("test.txt", "/%original_file_name%-%locale%")
+            .setBasePath(tempProject.getBasePath())
+            .build();
+
+        PropertiesBuilder.Messages messages = PropertiesWithFiles.CONFIGURATOR.checkProperties(props, CheckType.LINT);
+
+        assertTrue(messages.getErrors().isEmpty(), "Expected no errors when source file exists");
+    }
+
+    @Test
+    public void testCheckProperties_sourceFileNotExists_hasError() {
+        PropertiesWithFiles props = NewPropertiesWithFilesUtilBuilder
+            .minimalBuiltPropertiesBean("nonexistent.txt", "/%original_file_name%-%locale%")
+            .setBasePath(tempProject.getBasePath())
+            .build();
+
+        PropertiesBuilder.Messages messages = PropertiesWithFiles.CONFIGURATOR.checkProperties(props, CheckType.LINT);
+
+        assertFalse(messages.getErrors().isEmpty(), "Expected error when source file does not exist");
+        assertTrue(messages.getErrors().stream().anyMatch(e -> e.contains("No source files found")),
+            "Expected error message about missing source files");
+    }
+
+    @Test
+    public void testCheckProperties_sourceGlobPatternMatches_noError() {
+        tempProject.addFile("file1.xml", "content");
+        tempProject.addFile("file2.xml", "content");
+
+        PropertiesWithFiles props = NewPropertiesWithFilesUtilBuilder
+            .minimalBuiltPropertiesBean("*.xml", "/%original_file_name%-%locale%")
+            .setBasePath(tempProject.getBasePath())
+            .build();
+
+        PropertiesBuilder.Messages messages = PropertiesWithFiles.CONFIGURATOR.checkProperties(props, CheckType.LINT);
+
+        assertTrue(messages.getErrors().isEmpty(), "Expected no errors when glob pattern matches files");
+    }
+
+    @Test
+    public void testCheckProperties_sourceGlobPatternNoMatch_hasError() {
+        tempProject.addFile("file.txt", "content");
+
+        PropertiesWithFiles props = NewPropertiesWithFilesUtilBuilder
+            .minimalBuiltPropertiesBean("*.xml", "/%original_file_name%-%locale%")
+            .setBasePath(tempProject.getBasePath())
+            .build();
+
+        PropertiesBuilder.Messages messages = PropertiesWithFiles.CONFIGURATOR.checkProperties(props, CheckType.LINT);
+
+        assertFalse(messages.getErrors().isEmpty(), "Expected error when glob pattern matches no files");
+        assertTrue(messages.getErrors().stream().anyMatch(e -> e.contains("No source files found")),
+            "Expected error message about missing source files");
+    }
+
+    @Test
+    public void testCheckProperties_sourceDoubleAsteriskPattern_noError() {
+        tempProject.addFile("src/main/file.xml", "content");
+
+        PropertiesWithFiles props = NewPropertiesWithFilesUtilBuilder
+            .minimalBuiltPropertiesBean("**/*.xml", "/%original_file_name%-%locale%")
+            .setBasePath(tempProject.getBasePath())
+            .build();
+
+        PropertiesBuilder.Messages messages = PropertiesWithFiles.CONFIGURATOR.checkProperties(props, CheckType.LINT);
+
+        assertTrue(messages.getErrors().isEmpty(), "Expected no errors when ** pattern matches files");
     }
 }


### PR DESCRIPTION
# Add source file existence validation to `crowdin config lint`

## Summary

Add source file existence validation to `crowdin config lint` command.

### Problem

When a developer deletes a Gradle module (or any source files), the Crowdin sync workflow fails because the source files specified in the configuration no longer exist. Currently, there's no way to detect this misconfiguration before running the actual sync.

### Solution

The `config lint` command now validates that source files/patterns specified in the configuration actually match existing files on the filesystem. If no files match a source pattern, the command reports an error.

## Changes

- Added `checkSourceFilesExist()` method to validate source file patterns
- Added error message `error.config.source_not_found` for missing sources
- Added unit tests covering:
  - Exact file paths
  - Glob patterns (`*.xml`)
  - Recursive patterns (`**/*.xml`)

## Test plan

- [x] Run `crowdin config lint` with valid config — should pass
- [x] Run `crowdin config lint` with non-existent source path — should report error
- [x] Run `crowdin config lint` with glob pattern matching no files — should report error
- [x] Unit tests pass: `./gradlew test --tests "com.crowdin.cli.properties.*"`
