### PR TITLE
ci: switch npm publish workflow to staged publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,7 +122,7 @@ jobs:
         run: crowdin -V
 
       - name: Publish the package
-        run: npm publish --provenance
+        run: npm stage publish --provenance
 
   aur:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Switched the npm release workflow to staged publishing (npm stage publish). This adds an approval gate before a version becomes installable, reducing supply-chain risk while keeping our CI release flow unchanged otherwise.