### PR TITLE
fix: upload translations timeout

### DIFF
--- a/src/main/java/com/crowdin/cli/utils/concurrency/ConcurrencyUtil.java
+++ b/src/main/java/com/crowdin/cli/utils/concurrency/ConcurrencyUtil.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 public class ConcurrencyUtil {
 
     private static final int CROWDIN_API_MAX_CONCURRENT_REQUESTS = 4;
+    private static final int MIN_MINUTES_WAIT = 100;
 
     private ConcurrencyUtil() {
         throw new UnsupportedOperationException();
@@ -19,11 +20,11 @@ public class ConcurrencyUtil {
      * @param tasks list of tasks to execute in parallel
      */
     public static void executeAndWait(List<Runnable> tasks, boolean debug) {
-        run(tasks, CROWDIN_API_MAX_CONCURRENT_REQUESTS, tasks.size() * 2, debug);
+        run(tasks, CROWDIN_API_MAX_CONCURRENT_REQUESTS, Math.max(tasks.size() * 2, MIN_MINUTES_WAIT), debug);
     }
 
     public static void executeAndWaitSingleThread(List<Runnable> tasks, boolean debug) {
-        run(tasks, 1, 100, debug);
+        run(tasks, 1, MIN_MINUTES_WAIT, debug);
     }
 
     private static void run(List<Runnable> tasks, int threadQnt, int minutesWait, boolean debug) {


### PR DESCRIPTION
### Problem

Uploading a large translation file fails with a misleading error, even though the import is progressing normally on the server:

```
java.lang.RuntimeException: Failed to upload the translation file '.../Language_ar.properties'. Please contact our support team for help
Caused by: java.lang.InterruptedException: sleep interrupted
    at com.crowdin.cli.client.Client.executeAsyncActionWithoutSpinner(Client.java:94)
```

It reproduces consistently for large files (not an environmental/network issue). The progress output shows the import advancing the whole time (e.g. 0% → 7% over ~100 polls) right up until it's cut off.

**Reproducing command:**
```bash
crowdin upload translations --auto-approve-imported --branch <branch> --language <language> --plain --verbose
```

### Root cause

`ConcurrencyUtil.executeAndWait` sets the executor timeout to `tasks.size() * 2` minutes. When a `files` entry resolves to a single large file (e.g. uploading one language at a time), `tasks.size() == 1`, so the timeout is just **2 minutes**.

Large files take longer than 2 minutes to import, so `awaitTermination` expires, `executor.shutdownNow()` interrupts the polling thread mid-`Thread.sleep()`, and the resulting `InterruptedException` surfaces as the generic "Failed to upload" message.

### Fix

Add a minimum floor to the timeout so small batches aren't cut off prematurely, while keeping the existing scaling for large batches:

The `100`-minute floor matches the value already used by `executeAndWaitSingleThread` in the same class.

### Testing

Reproduced the failure before the change and confirmed it's resolved after building a local jar. The existing `ConcurrencyUtilsTest` tests pass, they verify task completion and don't exercise the timeout value. A dedicated test for the floor would require a task that sleeps past the old 2-minute limit, which isn't practical as a unit test.