### PR TITLE
fix: escape square brackets in `Utils.regexPath` (`--delete-obsolete` deleting valid files)

### DIFF
--- a/src/main/java/com/crowdin/cli/utils/PlaceholderUtil.java
+++ b/src/main/java/com/crowdin/cli/utils/PlaceholderUtil.java
@@ -81,8 +81,6 @@ public class PlaceholderUtil {
     public static final String ROUND_BRACKET_OPEN_REGEX = "\\(";
     public static final String ROUND_BRACKET_CLOSE = ")";
     public static final String ROUND_BRACKET_CLOSE_REGEX = "\\)";
-    public static final String ESCAPE_ROUND_BRACKET_OPEN = isWindows() ? "^(" : "\\(";
-    public static final String ESCAPE_ROUND_BRACKET_CLOSE = isWindows() ? "^)" : "\\)";
     private static final String ESCAPE_DOT = isWindows() ? "^." : "\\.";
     private static final String ESCAPE_DOT_REGEX = "\\.";
     private static final String ESCAPE_DOT_PLACEHOLDER = "{ESCAPE_DOT}";
@@ -305,8 +303,8 @@ public class PlaceholderUtil {
             .replace(ESCAPE_ASTERISK_PLACEHOLDER, ESCAPE_ASTERISK);
 
         toFormat = toFormat
-            .replace(ROUND_BRACKET_OPEN, ESCAPE_ROUND_BRACKET_OPEN)
-            .replace(ROUND_BRACKET_CLOSE, ESCAPE_ROUND_BRACKET_CLOSE)
+            .replace(ROUND_BRACKET_OPEN, ROUND_BRACKET_OPEN_REGEX)
+            .replace(ROUND_BRACKET_CLOSE, ROUND_BRACKET_CLOSE_REGEX)
             .replace(ESCAPE_ASTERISK_REPLACEMENT_FROM, ESCAPE_ASTERISK_REPLACEMENT_TO);
 
         if (isWindows()) {

--- a/src/main/java/com/crowdin/cli/utils/PlaceholderUtil.java
+++ b/src/main/java/com/crowdin/cli/utils/PlaceholderUtil.java
@@ -78,7 +78,9 @@ public class PlaceholderUtil {
     public static final String SQUARE_BRACKET_CLOSE = "]";
     public static final String SQUARE_BRACKET_CLOSE_REGEX = "\\]";
     public static final String ROUND_BRACKET_OPEN = "(";
+    public static final String ROUND_BRACKET_OPEN_REGEX = "\\(";
     public static final String ROUND_BRACKET_CLOSE = ")";
+    public static final String ROUND_BRACKET_CLOSE_REGEX = "\\)";
     public static final String ESCAPE_ROUND_BRACKET_OPEN = isWindows() ? "^(" : "\\(";
     public static final String ESCAPE_ROUND_BRACKET_CLOSE = isWindows() ? "^)" : "\\)";
     private static final String ESCAPE_DOT = isWindows() ? "^." : "\\.";

--- a/src/main/java/com/crowdin/cli/utils/PlaceholderUtil.java
+++ b/src/main/java/com/crowdin/cli/utils/PlaceholderUtil.java
@@ -73,6 +73,10 @@ public class PlaceholderUtil {
     private static final String SET_CLOSE_BRACKET = "]";
     public static final String PLUS = "+";
     public static final String PLUS_REGEX = "\\+";
+    public static final String SQUARE_BRACKET_OPEN = "[";
+    public static final String SQUARE_BRACKET_OPEN_REGEX = "\\[";
+    public static final String SQUARE_BRACKET_CLOSE = "]";
+    public static final String SQUARE_BRACKET_CLOSE_REGEX = "\\]";
     public static final String ROUND_BRACKET_OPEN = "(";
     public static final String ROUND_BRACKET_CLOSE = ")";
     public static final String ESCAPE_ROUND_BRACKET_OPEN = isWindows() ? "^(" : "\\(";

--- a/src/main/java/com/crowdin/cli/utils/Utils.java
+++ b/src/main/java/com/crowdin/cli/utils/Utils.java
@@ -119,8 +119,8 @@ public class Utils {
     public static String regexPath(String path) {
         if (path != null) {
             return path.replaceAll("\\\\", "\\\\\\\\")
-                .replace(ROUND_BRACKET_OPEN, ESCAPE_ROUND_BRACKET_OPEN)
-                .replace(ROUND_BRACKET_CLOSE, ESCAPE_ROUND_BRACKET_CLOSE)
+                .replace(ROUND_BRACKET_OPEN, ROUND_BRACKET_OPEN_REGEX)
+                .replace(ROUND_BRACKET_CLOSE, ROUND_BRACKET_CLOSE_REGEX)
                 .replace(PLUS, PLUS_REGEX)
                 .replace(SQUARE_BRACKET_OPEN, SQUARE_BRACKET_OPEN_REGEX)
                 .replace(SQUARE_BRACKET_CLOSE, SQUARE_BRACKET_CLOSE_REGEX);

--- a/src/main/java/com/crowdin/cli/utils/Utils.java
+++ b/src/main/java/com/crowdin/cli/utils/Utils.java
@@ -121,7 +121,9 @@ public class Utils {
             return path.replaceAll("\\\\", "\\\\\\\\")
                 .replace(ROUND_BRACKET_OPEN, ESCAPE_ROUND_BRACKET_OPEN)
                 .replace(ROUND_BRACKET_CLOSE, ESCAPE_ROUND_BRACKET_CLOSE)
-                .replace(PLUS, PLUS_REGEX);
+                .replace(PLUS, PLUS_REGEX)
+                .replace(SQUARE_BRACKET_OPEN, SQUARE_BRACKET_OPEN_REGEX)
+                .replace(SQUARE_BRACKET_CLOSE, SQUARE_BRACKET_CLOSE_REGEX);
         } else {
             return null;
         }

--- a/src/test/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtilsTest.java
+++ b/src/test/java/com/crowdin/cli/commands/functionality/ObsoleteSourcesUtilsTest.java
@@ -80,4 +80,30 @@ public class ObsoleteSourcesUtilsTest {
         assertEquals(1, obsoleteFiles.size());
         assertEquals(true, obsoleteFiles.containsKey(projectFilePath));
     }
+
+    // Issue: https://github.com/crowdin/crowdin-cli/issues/1028
+    @Test
+    public void testFindObsoleteProjectFileWithSquareBracketsInPath() {
+        String projectFilePath = Utils.normalizePath("packages/next/src/app/[locale]/(app)/agendas/locales/en.json");
+        Map<String, File> projectFilesFromApi = new HashMap<String, File>() {
+            {
+                put(projectFilePath, FileBuilder.standard()
+                        .setProjectId(projectId)
+                        .setIdentifiers("en.json", "json", fileId1, directoryId1, null)
+                        .setExportPattern("/%original_path%/%two_letters_code%.%file_extension%")
+                        .build());
+            }
+        };
+        boolean preserveHierarchy = true;
+        List<String> filesToUpload = Arrays.asList(projectFilePath);
+        String sourcePattern = Utils.normalizePath("/packages/next/src/**/locales/en.json");
+        String exportPattern = Utils.normalizePath("/%original_path%/%two_letters_code%.%file_extension%");
+        List<String> ignorePatterns = Arrays.asList();
+
+        Map<String, File> obsoleteFiles = ObsoleteSourcesUtils.findObsoleteProjectFiles(projectFilesFromApi,
+                preserveHierarchy,
+                filesToUpload, sourcePattern, exportPattern, ignorePatterns);
+
+        assertEquals(0, obsoleteFiles.size());
+    }
 }

--- a/src/test/java/com/crowdin/cli/utils/PlaceholderUtilTest.java
+++ b/src/test/java/com/crowdin/cli/utils/PlaceholderUtilTest.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static com.crowdin.cli.utils.AssertUtils.assertPathsEqualIgnoringSeparator;
@@ -246,5 +247,13 @@ public class PlaceholderUtilTest {
         assertTrue(PlaceholderUtil.validStringPattern("src/" + PlaceholderUtil.PLACEHOLDER_LANGUAGE + "/" + PlaceholderUtil.PLACEHOLDER_FILE_NAME, PlaceholderUtil.ALL_PLACEHOLDERS));
         assertFalse(PlaceholderUtil.validStringPattern("src/" + PlaceholderUtil.PLACEHOLDER_LANGUAGE + "/" + PlaceholderUtil.PLACEHOLDER_FILE_NAME, PlaceholderUtil.FILE_PLACEHOLDERS));
         assertFalse(PlaceholderUtil.validStringPattern("src/" + PlaceholderUtil.PLACEHOLDER_LANGUAGE + "/%invalid%", PlaceholderUtil.ALL_PLACEHOLDERS));
+    }
+
+    // Issue: https://github.com/crowdin/crowdin-cli/issues/1028
+    @Test
+    public void testFormatSourcePatternForRegexTreatsRoundBracketsAsLiterals() {
+        String regex = PlaceholderUtil.formatSourcePatternForRegex("app/(group)/*.json");
+        assertEquals("app/\\(group\\)/[^/]+\\.json", regex);
+        assertTrue(Pattern.compile("^" + regex + "$").asPredicate().test("app/(group)/en.json"));
     }
 }

--- a/src/test/java/com/crowdin/cli/utils/UtilsTest.java
+++ b/src/test/java/com/crowdin/cli/utils/UtilsTest.java
@@ -82,6 +82,7 @@ public class UtilsTest {
     @Test
     public void testRegexPath() {
         assertEquals("\\\\path\\\\to\\\\file", Utils.regexPath("\\path\\to\\file"));
+        assertEquals("app/\\[locale\\]/file", Utils.regexPath("app/[locale]/file"));
     }
 
     @Test

--- a/src/test/java/com/crowdin/cli/utils/UtilsTest.java
+++ b/src/test/java/com/crowdin/cli/utils/UtilsTest.java
@@ -83,6 +83,7 @@ public class UtilsTest {
     public void testRegexPath() {
         assertEquals("\\\\path\\\\to\\\\file", Utils.regexPath("\\path\\to\\file"));
         assertEquals("app/\\[locale\\]/file", Utils.regexPath("app/[locale]/file"));
+        assertEquals("app/\\(group\\)/file", Utils.regexPath("app/(group)/file"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #1028

## Problem

`Utils.regexPath()` escapes round brackets and `+` but not square brackets. `ObsoleteSourcesUtils.isFileNotInList()` uses it to build a regex from each remote file path and match it against the upload list; a path like `packages/next/src/app/[locale]/agendas/locales/en.json` (Next.js App Router) turns `[locale]` into a regex character class, the literal upload path never matches, and the file is wrongly flagged obsolete. `upload sources --delete-obsolete` then deletes it from the project and the subsequent update of the same file fails with `Error from server: <Code: 404, Message: File Not Found>`. Translations for those files are lost on every other run.

Reproduced with CLI 3.7.8 and 4.14.2 — full analysis and real-world CI logs in #1028.

## Fix

Escape `[` and `]` in `Utils.regexPath()`, following the same approach as the existing `+` escaping (#948). New constants in `PlaceholderUtil` mirror the `PLUS` / `PLUS_REGEX` naming (platform-independent, since the output is only ever consumed by `Pattern.compile` / `replaceFirst`).

## Tests

- `ObsoleteSourcesUtilsTest#testFindObsoleteProjectFileWithSquareBracketsInPath`: end-to-end repro of the issue scenario — fails before the fix (file flagged obsolete), passes after.
- `UtilsTest#testRegexPath`: assertion for bracket escaping.

Full test suite run before/after the change yields an identical result set (the failures present on a clean checkout in my environment are unrelated and unchanged).

## Windows note

The new repro test initially failed on `windows-latest`: round brackets were escaped with the cmd-style `^(` / `^)` (`ESCAPE_ROUND_BRACKET_OPEN/CLOSE`) on Windows, which is invalid inside a `Pattern.compile` regex and prevented any match — same obsolete-flagging symptom, parentheses-triggered.

Since the output of both `Utils.regexPath()` and `PlaceholderUtil.formatSourcePatternForRegex()` is consumed exclusively as a Java regex (`Pattern.compile` / `Pattern.matches` / `replaceFirst`), and unlike the dot/question/asterisk escapes the round-bracket ones were never normalized back to regex form in the final `isWindows()` block, both methods now use platform-independent `\(` / `\)` escapes (as `FileHelper` already did) and the unused `ESCAPE_ROUND_BRACKET_*` constants are removed. Covered by a new `PlaceholderUtilTest` case. The `^x` intermediate placeholders for `.` / `?` / `*` in `PlaceholderUtil` are left untouched.
