### PR TITLE
fix: respect ignore patterns with language placeholders on upload translations

### DIFF
--- a/src/main/java/com/crowdin/cli/commands/actions/UploadTranslationsAction.java
+++ b/src/main/java/com/crowdin/cli/commands/actions/UploadTranslationsAction.java
@@ -85,8 +85,12 @@ class UploadTranslationsAction implements NewAction<PropertiesWithFiles, Project
             : project.getProjectLanguages(false);
 
         for (FileBean file : pb.getFiles()) {
+            LanguageMapping localLanguageMapping =
+                LanguageMapping.fromConfigFileLanguageMapping(file.getLanguagesMapping());
+            LanguageMapping languageMapping =
+                LanguageMapping.populate(localLanguageMapping, serverLanguageMapping);
             List<String> fileSourcesWithoutIgnores = SourcesUtils
-                .getFiles(pb.getBasePath(), file.getSource(), file.getIgnore(), placeholderUtil)
+                .getFiles(pb.getBasePath(), file.getSource(), file.getIgnore(), placeholderUtil, languageMapping)
                 .map(java.io.File::getAbsolutePath)
                 .collect(Collectors.toList());
 

--- a/src/test/java/com/crowdin/cli/commands/actions/UploadTranslationsActionTest.java
+++ b/src/test/java/com/crowdin/cli/commands/actions/UploadTranslationsActionTest.java
@@ -76,6 +76,55 @@ public class UploadTranslationsActionTest {
     }
 
     @Test
+    public void testUploadTranslation_IgnoreWithMappedLanguagePlaceholder_Project() throws ResponseException {
+        // With a custom language mapping %locale% resolves to "ukrainian". The ignore uses %locale%,
+        // so `upload translations` must apply the mapping (like `upload sources` does) to exclude the
+        // localized variant; otherwise it resolves %locale% to the default and uploads the file too.
+        // See https://github.com/crowdin/crowdin-cli/issues/1030
+        project.addFile(Utils.normalizePath("messages.po"), "Hello, World!");
+        project.addFile(Utils.normalizePath("messages-ukrainian.po"), "Hello, World!");
+        project.addFile(Utils.normalizePath("messages.po-CR-ukrainian"), "Hello, World!");
+        project.addFile(Utils.normalizePath("messages-ukrainian.po-CR-ukrainian"), "Hello, World!");
+        NewPropertiesWithFilesUtilBuilder pbBuilder = NewPropertiesWithFilesUtilBuilder
+                .minimalBuiltPropertiesBean("*.po", Utils.PATH_SEPARATOR + "%original_file_name%-CR-%locale%", Arrays.asList("*-%locale%.po"))
+                .setBasePath(project.getBasePath());
+        PropertiesWithFiles pb = pbBuilder.build();
+        ProjectClient client = mock(ProjectClient.class);
+        CrowdinProjectFull build = ProjectBuilder.emptyProject(Long.parseLong(pb.getProjectId()))
+                .addFile("messages.po", "gettext", 301L, null, null)
+                .addFile("messages-ukrainian.po", "gettext", 302L, null, null)
+                .addLanguageMapping("ua", "locale", "ukrainian")
+                .build();
+        build.setType(Type.FILES_BASED);
+        ImportTranslationsRequest request = new ImportTranslationsRequest() {{
+            setStorageId(1L);
+            setFileId(301L);
+            setImportEqSuggestions(false);
+            setAutoApproveImported(false);
+            setTranslateHidden(false);
+            setLanguageIds(List.of("ua"));
+        }};
+        ImportTranslationsStatus importTranslationsStatus = new ImportTranslationsStatus();
+        importTranslationsStatus.setStatus("finished");
+        importTranslationsStatus.setIdentifier("123");
+
+        when(client.downloadFullProject(null))
+                .thenReturn(build);
+        when(client.uploadStorage(eq("messages.po-CR-ukrainian"), any()))
+                .thenReturn(1L);
+        when(client.importTranslations(eq(request))).thenReturn(importTranslationsStatus);
+
+        NewAction<PropertiesWithFiles, ProjectClient> action = new UploadTranslationsAction(false, null, null, false, false, false, false, false, false);
+        assertDoesNotThrow(() -> action.act(Outputter.getDefault(), pb, client));
+
+        // Only messages.po is uploaded; messages-ukrainian.po is excluded by the mapped placeholder ignore.
+        verify(client).downloadFullProject(null);
+        verify(client).uploadStorage(eq("messages.po-CR-ukrainian"), any());
+        verify(client).importTranslations(eq(request));
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
     public void testUploadBothTranslation_Project() throws ResponseException {
         project.addFile(Utils.normalizePath("first.po"), "Hello, World!");
         project.addFile(Utils.normalizePath("first.po-CR-uk-UA"), "Hello, World!");


### PR DESCRIPTION
## Problem

`crowdin upload translations` did not apply `ignore` patterns that contain language placeholders (e.g. `%locale%`, `%locale_with_underscore%`, `%two_letters_code%`), even though `crowdin upload sources` (push) does. A source that is correctly ignored on push was still picked up by `upload translations`.

## Cause

`UploadTranslationsAction` builds its source list with the 4-argument `SourcesUtils.getFiles(...)`, which passes a `null` `LanguageMapping`. `PlaceholderUtil.format` then resolves the placeholders in the ignore patterns without the project's language mapping, so patterns that rely on a (custom) mapping don't match. `UploadSourcesAction` uses the 5-argument overload and passes the populated mapping.

## Fix

Build the language mapping per file (local config + server, populated) and pass it to `getFiles`, mirroring `UploadSourcesAction`.

## Tests

Added `UploadTranslationsActionTest.testUploadTranslation_IgnoreWithMappedLanguagePlaceholder_Project`: with a custom language mapping, a localized file targeted by a `%locale%` ignore is now excluded. The test fails on the previous behavior (the file was uploaded) and passes with the fix. Full test suite green locally.

Closes #1030
