### PR TITLE
feat: show a clear message instead of a stack trace on unsupported Java versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,26 @@ if (!hasProperty('mainClass')) {
 
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
+// The CLI is compiled for Java 17, so on an older runtime the JVM fails to load the main class
+// with a raw UnsupportedClassVersionError before any of our code runs. The launcher source set is
+// compiled for an older release so it loads on any JVM, checks the version, and prints a clear
+// message instead (see com.crowdin.cli.Launcher). https://github.com/crowdin/crowdin-cli/issues/940
+sourceSets {
+    launcher {
+        java {
+            srcDirs = ['src/launcher/java']
+        }
+    }
+}
+
+sourceSets.launcher.compileClasspath += sourceSets.main.output + sourceSets.main.compileClasspath
+sourceSets.test.compileClasspath += sourceSets.launcher.output
+sourceSets.test.runtimeClasspath += sourceSets.launcher.output
+
+compileLauncherJava {
+    options.release = 8
+}
+
 repositories {
     mavenCentral()
     maven { url 'https://jitpack.io'}
@@ -65,14 +85,16 @@ wrapper {
 }
 
 jar {
+    from sourceSets.launcher.output
     manifest {
         attributes 'Implementation-Title': 'Crowdin CLI',
                 'Implementation-Version': archiveVersion,
-                'Main-Class': 'com.crowdin.cli.Cli'
+                'Main-Class': 'com.crowdin.cli.Launcher'
     }
 }
 
 shadowJar {
+    from sourceSets.launcher.output
     setArchivesBaseName('crowdin-cli')
     getArchiveClassifier().set('')
     minimize {

--- a/src/launcher/java/com/crowdin/cli/Launcher.java
+++ b/src/launcher/java/com/crowdin/cli/Launcher.java
@@ -1,0 +1,58 @@
+package com.crowdin.cli;
+
+/**
+ * Bootstrap entry point for the CLI.
+ *
+ * <p>The rest of the CLI is compiled for Java 17, so on an older runtime the JVM fails to load
+ * {@link Cli} with a raw {@code UnsupportedClassVersionError} and a stack trace before any of our
+ * code gets a chance to run. This class is compiled for an older release (see the {@code launcher}
+ * source set in {@code build.gradle}), so it loads on any JVM, checks the runtime version, and
+ * prints a clear message instead. On a supported runtime it simply delegates to {@link Cli}.
+ */
+public final class Launcher {
+
+    static final int MIN_JAVA_MAJOR = 17;
+
+    private Launcher() {
+    }
+
+    public static void main(String[] args) {
+        int major = parseMajor(System.getProperty("java.specification.version"));
+        if (major > 0 && major < MIN_JAVA_MAJOR) {
+            System.err.println("Crowdin CLI requires Java " + MIN_JAVA_MAJOR
+                + " or higher. Detected version: " + System.getProperty("java.version"));
+            System.err.println("Please update your Java Runtime Environment.");
+            System.exit(1);
+            return;
+        }
+        Cli.main(args);
+    }
+
+    /**
+     * Extracts the major version from a {@code java.specification.version} value, supporting both
+     * the legacy {@code "1.8"} scheme and the modern {@code "17"} scheme. Returns {@code 0} when the
+     * value is missing or unparseable, in which case the caller starts the CLI rather than blocking
+     * a user over an unrecognized version string.
+     */
+    static int parseMajor(String specVersion) {
+        if (specVersion == null) {
+            return 0;
+        }
+        String value = specVersion.trim();
+        if (value.isEmpty()) {
+            return 0;
+        }
+        if (value.startsWith("1.")) {
+            value = value.substring(2);
+        }
+        int separator = value.indexOf('.');
+        if (separator != -1) {
+            value = value.substring(0, separator);
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+}

--- a/src/test/java/com/crowdin/cli/LauncherTest.java
+++ b/src/test/java/com/crowdin/cli/LauncherTest.java
@@ -1,0 +1,47 @@
+package com.crowdin.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class LauncherTest {
+
+    @Test
+    void parsesLegacyOneDotScheme() {
+        assertEquals(8, Launcher.parseMajor("1.8"));
+        assertEquals(7, Launcher.parseMajor("1.7"));
+    }
+
+    @Test
+    void parsesModernSingleNumberScheme() {
+        assertEquals(17, Launcher.parseMajor("17"));
+        assertEquals(21, Launcher.parseMajor("21"));
+    }
+
+    @Test
+    void parsesModernSchemeWithMinorComponent() {
+        assertEquals(17, Launcher.parseMajor("17.0.5"));
+    }
+
+    @Test
+    void returnsZeroForMissingOrBlankValue() {
+        assertEquals(0, Launcher.parseMajor(null));
+        assertEquals(0, Launcher.parseMajor(""));
+        assertEquals(0, Launcher.parseMajor("   "));
+    }
+
+    @Test
+    void returnsZeroForUnparseableValue() {
+        assertEquals(0, Launcher.parseMajor("not-a-version"));
+    }
+
+    @Test
+    void thresholdRejectsOlderRuntimesAndAcceptsSupportedOnes() {
+        assertTrue(Launcher.parseMajor("1.8") < Launcher.MIN_JAVA_MAJOR);
+        assertTrue(Launcher.parseMajor("11") < Launcher.MIN_JAVA_MAJOR);
+        assertFalse(Launcher.parseMajor("17") < Launcher.MIN_JAVA_MAJOR);
+        assertFalse(Launcher.parseMajor("21") < Launcher.MIN_JAVA_MAJOR);
+    }
+}


### PR DESCRIPTION
Running the CLI on a JRE older than the required Java 17 fails with a raw `UnsupportedClassVersionError` stack trace. Resolves #940.

That error happens at class-load time — before any application code runs — so it can't be caught from within `Cli`. This adds a small `Launcher` entry point in a dedicated source set compiled with `--release 8`: it loads on any JVM, checks the runtime version, and either prints a clear message or delegates to `Cli`:

    Crowdin CLI requires Java 17 or higher. Detected version: 11.0.28
    Please update your Java Runtime Environment.

`Launcher` is now the jar's `Main-Class` and calls `Cli.main(...)` directly — a direct call keeps `Cli` from being dropped by the shaded-jar `minimize`.

Tests: `LauncherTest` covers the version parsing (`1.8` / `17` / `21` / malformed); verified on the built jar that Java 11 prints the message and exits 1 while Java 21 runs normally.
