### PR TITLE
fix: correct Java version check and PATH setup in install scripts

### DIFF
--- a/packages/zip/install-crowdin-cli.sh
+++ b/packages/zip/install-crowdin-cli.sh
@@ -18,7 +18,7 @@ if [[ "$_java" ]]; then
 
     version=$("$_java" -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
 
-    if [ $version -gt 7 ]; then
+    if [ "$version" -ge 17 ]; then
         echo Your Java version is "$version" - OK
 
         echo "Installing Crowdin CLI..."
@@ -32,7 +32,7 @@ if [[ "$_java" ]]; then
 
         sh -c "cat > /usr/local/bin/crowdin << EOF
 #!/bin/bash
-exec /usr/bin/java -jar '/usr/local/bin/crowdin-cli.jar' \"\\\$@\"
+exec '$_java' -jar '/usr/local/bin/crowdin-cli.jar' \"\\\$@\"
 EOF"
         chmod +x /usr/local/bin/crowdin
 
@@ -49,7 +49,7 @@ EOF"
         chmod +x /usr/local/bin/crowdin_uninstall
 
     else
-        echo Your Java version is "$version" - needs to be updated. You can download it from https://www.oracle.com/java/technologies/downloads/
+        echo Your Java version is "$version" - Crowdin CLI requires Java 17 or newer. You can download it from https://www.oracle.com/java/technologies/downloads/
     fi
 fi
 

--- a/packages/zip/setup_crowdin.bat
+++ b/packages/zip/setup_crowdin.bat
@@ -7,7 +7,7 @@ ECHO Setting CROWDIN_HOME environment variable
 setx /M CROWDIN_HOME "%cd%"
 
 ECHO Adding the current directory to PATH environment variable
-setx /M PATH "%PATH%;%cd%"
+powershell -NoProfile -Command "$p = [Environment]::GetEnvironmentVariable('Path', 'Machine'); if (($p -split ';') -notcontains '%cd%') { [Environment]::SetEnvironmentVariable('Path', $p.TrimEnd(';') + ';%cd%', 'Machine') }"
 
 if "%_JAVACMD"=="" (
   if not "%JAVA_HOME%"=="" (


### PR DESCRIPTION
- install-crowdin-cli.sh: require Java 17+ (was 8+) and use the validated java binary in the generated launcher (closes #840)
- setup_crowdin.bat: replace the setx PATH write, which truncates the stored value to 1024 characters and mixes the user PATH into the machine PATH, with a PowerShell append (closes #707)