### PR TITLE
fix(context): detect the AI context section by its markers

### DIFF
--- a/src/main/java/com/crowdin/cli/utils/AiContextUtil.java
+++ b/src/main/java/com/crowdin/cli/utils/AiContextUtil.java
@@ -11,8 +11,11 @@ import java.util.Objects;
 
 public class AiContextUtil {
 
-    private static final String AI_CONTEXT_SECTION_START = "\n\n✨ AI Context\n";
-    private static final String AI_CONTEXT_SECTION_END = "\n✨ 🔚";
+    private static final String AI_CONTEXT_MARKER_START = "✨ AI Context";
+    private static final String AI_CONTEXT_MARKER_END = "✨ 🔚";
+
+    private static final String AI_CONTEXT_SECTION_START = "\n\n" + AI_CONTEXT_MARKER_START + "\n";
+    private static final String AI_CONTEXT_SECTION_END = "\n" + AI_CONTEXT_MARKER_END;
 
     private AiContextUtil() {
     }
@@ -22,7 +25,7 @@ public class AiContextUtil {
             return "";
         }
 
-        int startIndex = context.indexOf(AI_CONTEXT_SECTION_START);
+        int startIndex = context.indexOf(AI_CONTEXT_MARKER_START);
         if (startIndex != -1) {
             return context.substring(0, startIndex).trim();
         }
@@ -35,11 +38,16 @@ public class AiContextUtil {
             return "";
         }
 
-        int startIndex = context.indexOf(AI_CONTEXT_SECTION_START);
-        int endIndex = context.indexOf(AI_CONTEXT_SECTION_END);
+        int startIndex = context.indexOf(AI_CONTEXT_MARKER_START);
+        if (startIndex == -1) {
+            return "";
+        }
 
-        if (startIndex != -1 && endIndex != -1 && startIndex < endIndex) {
-            return context.substring(startIndex + AI_CONTEXT_SECTION_START.length(), endIndex);
+        int sectionStart = startIndex + AI_CONTEXT_MARKER_START.length();
+        int endIndex = context.indexOf(AI_CONTEXT_MARKER_END, sectionStart);
+
+        if (endIndex != -1) {
+            return context.substring(sectionStart, endIndex).trim();
         }
 
         return "";

--- a/src/test/java/com/crowdin/cli/utils/AiContextUtilTest.java
+++ b/src/test/java/com/crowdin/cli/utils/AiContextUtilTest.java
@@ -20,6 +20,10 @@ public class AiContextUtilTest {
                 "",
                 AiContextUtil.getManualContext("")
         );
+        assertEquals(
+                "",
+                AiContextUtil.getManualContext("✨ AI Context\nThis is the AI context.\n✨ 🔚")
+        );
     }
 
     @Test
@@ -35,6 +39,10 @@ public class AiContextUtilTest {
         assertEquals(
                 "",
                 AiContextUtil.getAiContextSection("")
+        );
+        assertEquals(
+                "This is the AI context.",
+                AiContextUtil.getAiContextSection("✨ AI Context\nThis is the AI context.\n✨ 🔚")
         );
     }
 }


### PR DESCRIPTION
The API trims a string's context, so a section written for a string with no manual context loses its leading blank line and stops matching `"\n\n✨ AI Context\n"`. Such strings were counted as manual context by `context status`, missing from `context download --status ai`, and skipped by `context reset`.

Locate the section by the marker text alone. Already stored contexts are read correctly, so no re-upload is needed.