### PR TITLE
fix: tm/glossary import update

### DIFF
--- a/src-next/cli/commands/bundle/BundleCommand.ts
+++ b/src-next/cli/commands/bundle/BundleCommand.ts
@@ -10,6 +10,7 @@ import type { AddBundlePayload, BundleView } from '@/cli/services/BundleService.
 import type { GetBundleService, GetConfig, GetOutput } from '@/cli/services.ts';
 import type { CommandDef } from '@/cli/types.ts';
 import { colors } from '@/cli/utils/colors.ts';
+import { downloadToFile } from '@/cli/utils/downloadToFile.ts';
 import { isMachineFormat } from '@/cli/utils/formatter.ts';
 import { openUrl } from '@/cli/utils/open.ts';
 import type { View } from '@/cli/utils/output.ts';
@@ -271,9 +272,8 @@ export default class BundleCommand {
     // Archive and extracted files both land under basePath (matches `download` keep-archive behaviour).
     const archivePath = path.join(config.basePath, `bundle-${exportId}.zip`);
     const downloadUrl = await bundleService.getDownloadUrl(id, exportId);
-    const response = await fetch(downloadUrl);
 
-    await Bun.write(archivePath, response);
+    await downloadToFile(downloadUrl, archivePath);
     output.success(`#${bundle.id} '${bundle.name}' has been successfully downloaded`);
 
     const zip = new AdmZip(archivePath);

--- a/src-next/cli/commands/download/DownloadCommand.ts
+++ b/src-next/cli/commands/download/DownloadCommand.ts
@@ -18,6 +18,7 @@ import type {
   GetTranslationService,
 } from '@/cli/services.ts';
 import type { CommandDef } from '@/cli/types.ts';
+import { downloadToFile } from '@/cli/utils/downloadToFile.ts';
 import { isMachineFormat, isStructuredFormat } from '@/cli/utils/formatter.ts';
 import type { Output } from '@/cli/utils/output.ts';
 import { matchesManagerSourceFile, matchesSourcePattern, replaceUnaryAsterisk } from '@/lib/config/projectFileMatch.ts';
@@ -181,12 +182,11 @@ export default class DownloadCommand {
     if (options.reviewed) {
       const build = await fileService.buildReviewedSources(branch?.id);
       const downloadUrl = await fileService.getReviewedSourcesDownloadUrl(build.data.id);
-      const response = await fetch(downloadUrl);
       const tempDir = await mkdtemp(path.join(tmpdir(), 'crowdin-reviewed-sources-'));
 
       try {
         const archivePath = path.join(tempDir, 'reviewed.zip');
-        await Bun.write(archivePath, response);
+        await downloadToFile(downloadUrl, archivePath);
 
         // The reviewed archive nests every file under a `<source_language_id>-REV` directory;
         // strip that prefix so keys line up with the project file paths (mirrors Java).
@@ -253,10 +253,8 @@ export default class DownloadCommand {
       try {
         const filePath = path.join(config.basePath, download.destination);
         const downloadUrl = await fileService.getSourceFileDownloadUrl(download.fileId);
-        const response = await fetch(downloadUrl);
 
-        await mkdir(path.dirname(filePath), { recursive: true });
-        await Bun.write(filePath, response);
+        await downloadToFile(downloadUrl, filePath);
         output.success(`File '${download.relativePath}'`);
         downloadedFiles.push({ path: download.relativePath, action: 'downloaded' });
       } catch (error) {
@@ -411,13 +409,12 @@ export default class DownloadCommand {
         }
 
         const downloadUrl = await translationService.getTranslationDownloadUrl(build.data.id);
-        const response = await fetch(downloadUrl);
 
         const tempDir = await mkdtemp(path.join(tmpdir(), 'crowdin-translations-'));
         tempDirs.push(tempDir);
         const archivePath = path.join(tempDir, 'translations.zip');
 
-        await Bun.write(archivePath, response);
+        await downloadToFile(downloadUrl, archivePath);
 
         // Pseudo builds always map all target languages (Java ignores export_languages/exclude here).
         const mappingLanguages = group.pseudo ? projectLanguages : resolvedLanguages;

--- a/src-next/cli/commands/file/FileCommand.ts
+++ b/src-next/cli/commands/file/FileCommand.ts
@@ -1,5 +1,4 @@
 import { existsSync, statSync } from 'node:fs';
-import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import type { ResponseObject, SourceFilesModel, UploadStorageModel } from '@crowdin/crowdin-api-client';
 import { ProjectsGroupsModel } from '@crowdin/crowdin-api-client';
@@ -25,6 +24,7 @@ import type {
   GetTranslationService,
 } from '@/cli/services.ts';
 import type { CommandDef } from '@/cli/types.ts';
+import { downloadToFile } from '@/cli/utils/downloadToFile.ts';
 import { printFileTree } from '@/cli/utils/fileTree.ts';
 import { isMachineFormat, isStructuredFormat } from '@/cli/utils/formatter.ts';
 import type { Output, View } from '@/cli/utils/output.ts';
@@ -632,8 +632,7 @@ export default class FileCommand {
 
         try {
           const downloadUrl = await fileService.getSourceFileDownloadUrl(projectFile.data.id);
-          await mkdir(path.dirname(fullFilePath), { recursive: true });
-          await Bun.write(fullFilePath, await fetch(downloadUrl));
+          await downloadToFile(downloadUrl, fullFilePath);
         } catch (error) {
           throw toCliError(error, `Failed to download '${filePath}'`);
         }
@@ -708,8 +707,7 @@ export default class FileCommand {
 
       try {
         const url = await translationService.buildProjectFileTranslation(sourceFile.data.id, language.id);
-        await mkdir(path.dirname(fullFilePath), { recursive: true });
-        await Bun.write(fullFilePath, await fetch(url));
+        await downloadToFile(url, fullFilePath);
       } catch (error) {
         throw toCliError(error, `Failed to download '${destPath}'`);
       }

--- a/src-next/cli/commands/glossary/GlossaryCommand.ts
+++ b/src-next/cli/commands/glossary/GlossaryCommand.ts
@@ -10,6 +10,7 @@ import type { GlobalOptions } from '@/cli/options.ts';
 import type { GlossaryService } from '@/cli/services/GlossaryService.ts';
 import type { GetApiClient, GetGlossaryService, GetOutput, GetStorageService } from '@/cli/services.ts';
 import type { CommandDef } from '@/cli/types.ts';
+import { downloadToFile } from '@/cli/utils/downloadToFile.ts';
 import { parseNumericId, parseScheme, toArray } from '@/cli/utils/parsing.ts';
 import {
   firstLineContainsHeader as firstLineContainsHeaderOption,
@@ -129,10 +130,9 @@ export default class GlossaryCommand {
 
     const exportId = await glossaryService.export(glossary.id, format);
     const downloadUrl = await glossaryService.getDownloadUrl(glossary.id, exportId);
-    const response = await fetch(downloadUrl);
 
     try {
-      await Bun.write(to, response);
+      await downloadToFile(downloadUrl, to);
     } catch (error) {
       throw toCliError(error, `Failed to write to the file '${to}'`);
     }

--- a/src-next/cli/commands/glossary/GlossaryCommand.ts
+++ b/src-next/cli/commands/glossary/GlossaryCommand.ts
@@ -203,7 +203,8 @@ export default class GlossaryCommand {
 
     output.success(`Imported in #${glossary.id} '${glossary.name}' glossary`);
     // The sentence above is text-only; the glossary itself is what a machine format owes the caller.
-    output.item(glossary, createGlossaryView(), { mark: false });
+    // Refetched: the copy from before the import still carries the old term count.
+    output.item(await glossaryService.get(glossary.id), createGlossaryView(), { mark: false });
   };
 
   private async loadTerms(

--- a/src-next/cli/commands/glossary/views.ts
+++ b/src-next/cli/commands/glossary/views.ts
@@ -21,9 +21,7 @@ export function createGlossaryView({
   return {
     text: (glossary) =>
       [
-        `${colors.yellow(`#${glossary.id}`)} ${colors.green(glossary.name)} (${colors.red(
-          `terms: ${glossary.terms ?? 0}`,
-        )})`,
+        `${colors.yellow(`#${glossary.id}`)} ${glossary.name} (${colors.green(`terms: ${glossary.terms ?? 0}`)})`,
         ...(verbose ? (terms.get(glossary.id) ?? []).map(termLine) : []),
       ].join('\n'),
     plain: (glossary) => glossary.name,

--- a/src-next/cli/commands/tm/TmCommand.ts
+++ b/src-next/cli/commands/tm/TmCommand.ts
@@ -10,6 +10,7 @@ import type { GlobalOptions } from '@/cli/options.ts';
 import type { GetApiClient, GetOutput, GetStorageService, GetTmService } from '@/cli/services.ts';
 import type { CommandDef } from '@/cli/types.ts';
 import { colors } from '@/cli/utils/colors.ts';
+import { downloadToFile } from '@/cli/utils/downloadToFile.ts';
 import type { View } from '@/cli/utils/output.ts';
 import { parseNumericId, parseScheme, toArray } from '@/cli/utils/parsing.ts';
 import {
@@ -140,10 +141,9 @@ export default class TmCommand {
 
     const exportId = await tmService.export(tm.id, options.sourceLanguageId, options.targetLanguageId, format);
     const downloadUrl = await tmService.getDownloadUrl(tm.id, exportId);
-    const response = await fetch(downloadUrl);
 
     try {
-      await Bun.write(to, response);
+      await downloadToFile(downloadUrl, to);
     } catch (error) {
       throw toCliError(error, `Failed to write to the file '${to}'`);
     }

--- a/src-next/cli/commands/tm/TmCommand.ts
+++ b/src-next/cli/commands/tm/TmCommand.ts
@@ -43,7 +43,6 @@ const UPLOAD_EXTENSIONS = ['tmx', 'csv', 'xls', 'xlsx'];
 const SCHEME_EXTENSIONS = ['csv', 'xls', 'xlsx'];
 const DEFAULT_TM_NAME = 'Created in Crowdin CLI (%s)';
 
-// Java message.tm.list: id, name, segment count.
 const tmView: View<TranslationMemoryModel.TranslationMemory> = {
   text: (tm) => `${colors.yellow(`#${tm.id}`)} ${tm.name} (${colors.green(`segments: ${tm.segmentsCount}`)})`,
   plain: (tm) => tm.name,

--- a/src-next/cli/commands/tm/TmCommand.ts
+++ b/src-next/cli/commands/tm/TmCommand.ts
@@ -213,6 +213,7 @@ export default class TmCommand {
 
     output.success(`Imported in #${tm.id} '${tm.name}' translation memory`);
     // The sentence above is text-only; the memory itself is what a machine format owes the caller.
-    output.item(tm, tmView, { mark: false });
+    // Refetched: the copy from before the import still carries the old segment count.
+    output.item(await tmService.get(tm.id), tmView, { mark: false });
   };
 }

--- a/src-next/cli/services/GlossaryService.ts
+++ b/src-next/cli/services/GlossaryService.ts
@@ -81,10 +81,20 @@ export class GlossaryService {
   }
 
   async import(glossaryId: number, request: GlossariesModel.GlossaryFile): Promise<void> {
-    try {
-      await this.apiClient.glossariesApi.importGlossaryFile(glossaryId, request);
-    } catch (error) {
-      throw toCliError(error, 'Failed to import glossary');
-    }
+    await withSpinner(
+      this.output,
+      'glossaryImport',
+      { start: 'Importing glossary', stop: 'Importing glossary (100%)', fail: 'Failed to import glossary' },
+      async () => {
+        const started = await this.apiClient.glossariesApi.importGlossaryFile(glossaryId, request);
+
+        await pollUntilFinished(
+          started,
+          ({ identifier }) => this.apiClient.glossariesApi.checkGlossaryImportStatus(glossaryId, identifier),
+          'The import has failed',
+          (status) => this.output.spinner('glossaryImport', 'message', `Importing glossary (${status.progress}%)`),
+        );
+      },
+    );
   }
 }

--- a/src-next/cli/services/TmService.ts
+++ b/src-next/cli/services/TmService.ts
@@ -85,10 +85,24 @@ export class TmService {
   }
 
   async import(tmId: number, request: TranslationMemoryModel.ImportTranslationMemoryRequest): Promise<void> {
-    try {
-      await this.apiClient.translationMemoryApi.importTm(tmId, request);
-    } catch (error) {
-      throw toCliError(error, 'Failed to import translation memory');
-    }
+    await withSpinner(
+      this.output,
+      'tmImport',
+      {
+        start: 'Importing translation memory',
+        stop: 'Importing translation memory (100%)',
+        fail: 'Failed to import translation memory',
+      },
+      async () => {
+        const started = await this.apiClient.translationMemoryApi.importTm(tmId, request);
+
+        await pollUntilFinished(
+          started,
+          ({ identifier }) => this.apiClient.translationMemoryApi.checkImportStatus(tmId, identifier),
+          'The import has failed',
+          (status) => this.output.spinner('tmImport', 'message', `Importing translation memory (${status.progress}%)`),
+        );
+      },
+    );
   }
 }

--- a/src-next/cli/utils/downloadToFile.ts
+++ b/src-next/cli/utils/downloadToFile.ts
@@ -31,7 +31,13 @@ export async function downloadToFile(url: string, destination: string): Promise<
     throw new CliError(`Download failed with status ${response.status}`);
   }
 
-  await mkdir(path.dirname(destination), { recursive: true });
+  // Bun on Windows rejects a recursive mkdir of a directory that already exists, which a bare file
+  // name ('.') always is; POSIX treats it as a no-op.
+  await mkdir(path.dirname(destination), { recursive: true }).catch((error: NodeJS.ErrnoException) => {
+    if (error.code !== 'EEXIST') {
+      throw error;
+    }
+  });
 
   // Randomised so two downloads racing for one destination can't write to the same part file.
   const partPath = `${destination}.${Math.random().toString(36).slice(2, 10)}.part`;

--- a/src-next/cli/utils/downloadToFile.ts
+++ b/src-next/cli/utils/downloadToFile.ts
@@ -1,0 +1,56 @@
+import { createWriteStream } from 'node:fs';
+import { mkdir, rename, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import CliError from '@/cli/errors/CliError.ts';
+
+/**
+ * Streams a download to a local file, creating the parent directory.
+ *
+ * Not `Bun.write(path, response)`: on Bun 1.4.0 that call never settles when the GC collects the
+ * Response while the body is still arriving (oven-sh/bun#40278), so the CLI stops with no file, no
+ * error and no exit. Piping the body through node's stream pipeline is the same single streaming
+ * pass without the stall.
+ *
+ * Two spellings that look tidier are silently wrong on the same version: `Bun.write(path,
+ * response.body)` stringifies the stream and writes 23 bytes of "[object ReadableStream]", and
+ * `writeFile(path, Readable.fromWeb(response.body))` inflates binary bodies by ~3% once they arrive
+ * in more than one chunk. Both exit 0, and a single-chunk body hides both.
+ *
+ * The bytes land in a sibling `.part` file and are renamed over the destination only once the whole
+ * body has arrived: a download that dies halfway leaves the previous local file alone instead of
+ * replacing it with a truncated one.
+ */
+export async function downloadToFile(url: string, destination: string): Promise<void> {
+  const response = await fetch(url);
+
+  // The signed URLs answer errors with a body of their own; without this the XML would be written
+  // out as if it were the requested file.
+  if (!response.ok || !response.body) {
+    throw new CliError(`Download failed with status ${response.status}`);
+  }
+
+  await mkdir(path.dirname(destination), { recursive: true });
+
+  // Randomised so two downloads racing for one destination can't write to the same part file.
+  const partPath = `${destination}.${Math.random().toString(36).slice(2, 10)}.part`;
+  const sink = createWriteStream(partPath);
+
+  try {
+    await pipeline(Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]), sink);
+
+    // A body cut short mid-transfer can still end the stream cleanly, and the truncated file would
+    // then be renamed over a good one.
+    const expected = Number(response.headers.get('content-length'));
+
+    if (Number.isFinite(expected) && expected > 0 && sink.bytesWritten !== expected) {
+      throw new CliError(`Download is incomplete: got ${sink.bytesWritten} of ${expected} bytes`);
+    }
+
+    await rename(partPath, destination);
+  } catch (error) {
+    await unlink(partPath).catch(() => {});
+    throw error;
+  }
+}

--- a/tests/cli/commands/glossary/GlossaryCommand.test.ts
+++ b/tests/cli/commands/glossary/GlossaryCommand.test.ts
@@ -339,8 +339,9 @@ describe('GlossaryCommand', () => {
 
       await glossaryCommand.uploadAction(createCommandContext({ language: 'uk' }, [tbxFile]));
 
-      expect(glossaryService.get).not.toHaveBeenCalled();
       expect(glossaryService.add).toHaveBeenCalledWith({ name: 'Created in Crowdin CLI (file.tbx)', languageId: 'uk' });
+      // The only `get` is the post-import refetch for the echoed term count.
+      expect(glossaryService.get).toHaveBeenCalledWith(43);
       expect(glossaryService.import).toHaveBeenCalledWith(43, { storageId: 52 });
     });
 

--- a/tests/cli/commands/glossary/GlossaryCommand.test.ts
+++ b/tests/cli/commands/glossary/GlossaryCommand.test.ts
@@ -204,13 +204,21 @@ describe('GlossaryCommand', () => {
   });
 
   describe('download', () => {
+    let cwd: string;
+
     beforeEach(() => {
       spyOn(globalThis, 'fetch').mockResolvedValue(new Response('glossary-content'));
+      // The default target is a bare file name, so the writes have to land somewhere disposable.
+      cwd = process.cwd();
+      process.chdir(tempDir);
+    });
+
+    afterEach(() => {
+      process.chdir(cwd);
     });
 
     test('downloads glossary by id with the default file name', async () => {
       const glossaryCommand = createGlossaryCommand();
-      const write = spyOn(Bun, 'write').mockResolvedValue(0 as never);
       output = createOutput({ ...globalOptions, output: 'text' });
 
       await glossaryCommand.downloadAction(createCommandContext({}, ['42']));
@@ -218,7 +226,7 @@ describe('GlossaryCommand', () => {
       expect(glossaryService.get).toHaveBeenCalledWith(42);
       expect(glossaryService.export).toHaveBeenCalledWith(42, undefined);
       expect(glossaryService.getDownloadUrl).toHaveBeenCalledWith(42, 'export-id');
-      expect(write).toHaveBeenCalledWith('forty-two.tbx', expect.anything());
+      expect(await Bun.file(join(tempDir, 'forty-two.tbx')).text()).toBe('glossary-content');
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining("'forty-two.tbx' downloaded successfully"));
     });
 
@@ -226,7 +234,6 @@ describe('GlossaryCommand', () => {
     // way to learn where the file landed — the message used to be text-only.
     test('prints the written path alone in plain', async () => {
       const glossaryCommand = createGlossaryCommand();
-      spyOn(Bun, 'write').mockResolvedValue(0 as never);
       output = createOutput({ ...globalOptions, output: 'plain' });
 
       await glossaryCommand.downloadAction(createCommandContext({ output: 'plain' }, ['42']));
@@ -236,7 +243,6 @@ describe('GlossaryCommand', () => {
 
     test('carries the written path in a machine format', async () => {
       const glossaryCommand = createGlossaryCommand();
-      spyOn(Bun, 'write').mockResolvedValue(0 as never);
       const item = spyOn(output, 'item');
 
       await glossaryCommand.downloadAction(createCommandContext({}, ['42']));
@@ -246,23 +252,21 @@ describe('GlossaryCommand', () => {
 
     test('downloads to the specified file and derives format from its extension', async () => {
       const glossaryCommand = createGlossaryCommand();
-      const write = spyOn(Bun, 'write').mockResolvedValue(0 as never);
       const to = join(tempDir, 'glossary.csv');
 
       await glossaryCommand.downloadAction(createCommandContext({ to }, ['42']));
 
       expect(glossaryService.export).toHaveBeenCalledWith(42, 'csv');
-      expect(write).toHaveBeenCalledWith(to, expect.anything());
+      expect(await Bun.file(to).text()).toBe('glossary-content');
     });
 
     test('passes file format to the export', async () => {
       const glossaryCommand = createGlossaryCommand();
-      spyOn(Bun, 'write').mockResolvedValue(0 as never);
 
       await glossaryCommand.downloadAction(createCommandContext({ format: 'csv' }, ['42']));
 
       expect(glossaryService.export).toHaveBeenCalledWith(42, 'csv');
-      expect(Bun.write).toHaveBeenCalledWith('forty-two.csv', expect.anything());
+      expect(await Bun.file(join(tempDir, 'forty-two.csv')).text()).toBe('glossary-content');
     });
 
     test('throws error for unsupported --to extension', async () => {
@@ -293,12 +297,12 @@ describe('GlossaryCommand', () => {
       expect(glossaryService.export).not.toHaveBeenCalled();
     });
 
-    test('throws CliError when writing the file fails', async () => {
+    test('throws CliError when the download fails', async () => {
       const glossaryCommand = createGlossaryCommand();
-      spyOn(Bun, 'write').mockRejectedValue(new Error('permission denied'));
+      spyOn(globalThis, 'fetch').mockResolvedValue(new Response('nope', { status: 500 }));
 
       expect(glossaryCommand.downloadAction(createCommandContext({}, ['42']))).rejects.toThrow(
-        new CliError("Failed to write to the file 'forty-two.tbx'. permission denied"),
+        new CliError('Download failed with status 500'),
       );
     });
   });

--- a/tests/cli/commands/tm/TmCommand.test.ts
+++ b/tests/cli/commands/tm/TmCommand.test.ts
@@ -160,13 +160,21 @@ describe('TmCommand', () => {
   });
 
   describe('download', () => {
+    let cwd: string;
+
     beforeEach(() => {
       spyOn(globalThis, 'fetch').mockResolvedValue(new Response('tm-content'));
+      // The default target is a bare file name, so the writes have to land somewhere disposable.
+      cwd = process.cwd();
+      process.chdir(tempDir);
+    });
+
+    afterEach(() => {
+      process.chdir(cwd);
     });
 
     test('downloads translation memory by id with the default file name', async () => {
       const tmCommand = createTmCommand();
-      const write = spyOn(Bun, 'write').mockResolvedValue(0 as never);
       output = createOutput({ ...globalOptions, output: 'text' });
 
       await tmCommand.downloadAction(createCommandContext({}, ['42']));
@@ -174,7 +182,7 @@ describe('TmCommand', () => {
       expect(tmService.get).toHaveBeenCalledWith(42);
       expect(tmService.export).toHaveBeenCalledWith(42, undefined, undefined, undefined);
       expect(tmService.getDownloadUrl).toHaveBeenCalledWith(42, 'export-id');
-      expect(write).toHaveBeenCalledWith('42.tmx', expect.anything());
+      expect(await Bun.file(join(tempDir, '42.tmx')).text()).toBe('tm-content');
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining("'42.tmx' downloaded successfully"));
     });
 
@@ -182,7 +190,6 @@ describe('TmCommand', () => {
     // way to learn where the file landed — the message used to be text-only.
     test('prints the written path alone in plain', async () => {
       const tmCommand = createTmCommand();
-      spyOn(Bun, 'write').mockResolvedValue(0 as never);
       output = createOutput({ ...globalOptions, output: 'plain' });
 
       await tmCommand.downloadAction(createCommandContext({ output: 'plain' }, ['42']));
@@ -192,7 +199,6 @@ describe('TmCommand', () => {
 
     test('carries the written path in a machine format', async () => {
       const tmCommand = createTmCommand();
-      spyOn(Bun, 'write').mockResolvedValue(0 as never);
       const item = spyOn(output, 'item');
 
       await tmCommand.downloadAction(createCommandContext({}, ['42']));
@@ -202,25 +208,23 @@ describe('TmCommand', () => {
 
     test('downloads to the specified file and derives format from its extension', async () => {
       const tmCommand = createTmCommand();
-      const write = spyOn(Bun, 'write').mockResolvedValue(0 as never);
       const to = join(tempDir, 'memory.csv');
 
       await tmCommand.downloadAction(createCommandContext({ to }, ['42']));
 
       expect(tmService.export).toHaveBeenCalledWith(42, undefined, undefined, 'csv');
-      expect(write).toHaveBeenCalledWith(to, expect.anything());
+      expect(await Bun.file(to).text()).toBe('tm-content');
     });
 
     test('passes language pair and file format to the export', async () => {
       const tmCommand = createTmCommand();
-      spyOn(Bun, 'write').mockResolvedValue(0 as never);
 
       await tmCommand.downloadAction(
         createCommandContext({ sourceLanguageId: 'en', targetLanguageId: 'uk', format: 'csv' }, ['42']),
       );
 
       expect(tmService.export).toHaveBeenCalledWith(42, 'en', 'uk', 'csv');
-      expect(Bun.write).toHaveBeenCalledWith('42.csv', expect.anything());
+      expect(await Bun.file(join(tempDir, '42.csv')).text()).toBe('tm-content');
     });
 
     test('throws error for unsupported --to extension', async () => {
@@ -269,12 +273,12 @@ describe('TmCommand', () => {
       expect(tmService.export).not.toHaveBeenCalled();
     });
 
-    test('throws CliError when writing the file fails', async () => {
+    test('throws CliError when the download fails', async () => {
       const tmCommand = createTmCommand();
-      spyOn(Bun, 'write').mockRejectedValue(new Error('permission denied'));
+      spyOn(globalThis, 'fetch').mockResolvedValue(new Response('nope', { status: 500 }));
 
       expect(tmCommand.downloadAction(createCommandContext({}, ['42']))).rejects.toThrow(
-        new CliError("Failed to write to the file '42.tmx'. permission denied"),
+        new CliError('Download failed with status 500'),
       );
     });
   });

--- a/tests/cli/commands/tm/TmCommand.test.ts
+++ b/tests/cli/commands/tm/TmCommand.test.ts
@@ -315,8 +315,9 @@ describe('TmCommand', () => {
 
       await tmCommand.uploadAction(createCommandContext({ language: 'uk' }, [tmxFile]));
 
-      expect(tmService.get).not.toHaveBeenCalled();
       expect(tmService.add).toHaveBeenCalledWith({ name: 'Created in Crowdin CLI (file.tmx)', languageId: 'uk' });
+      // The only `get` is the post-import refetch for the echoed segment count.
+      expect(tmService.get).toHaveBeenCalledWith(43);
       expect(tmService.import).toHaveBeenCalledWith(43, { storageId: 52 });
     });
 

--- a/tests/cli/services/GlossaryService.test.ts
+++ b/tests/cli/services/GlossaryService.test.ts
@@ -195,7 +195,9 @@ describe('GlossaryService', () => {
 
   describe('import', () => {
     test('starts the import', async () => {
-      spyOn(apiClient.glossariesApi, 'importGlossaryFile').mockResolvedValue({} as never);
+      spyOn(apiClient.glossariesApi, 'importGlossaryFile').mockResolvedValue({
+        data: { identifier: 'import-id', status: 'finished' },
+      } as never);
 
       await glossaryService.import(42, { storageId: 52, scheme: { term_en: 0 }, firstLineContainsHeader: true });
 
@@ -204,6 +206,29 @@ describe('GlossaryService', () => {
         scheme: { term_en: 0 },
         firstLineContainsHeader: true,
       });
+    });
+
+    test('polls import status until finished', async () => {
+      spyOn(apiClient.glossariesApi, 'importGlossaryFile').mockResolvedValue({
+        data: { identifier: 'import-id', status: 'created', progress: 0 },
+      } as never);
+      spyOn(apiClient.glossariesApi, 'checkGlossaryImportStatus')
+        .mockResolvedValueOnce({ data: { identifier: 'import-id', status: 'inProgress', progress: 50 } } as never)
+        .mockResolvedValueOnce({ data: { identifier: 'import-id', status: 'finished' } } as never);
+      spyOn(Bun, 'sleep').mockResolvedValue(undefined);
+
+      await glossaryService.import(42, { storageId: 52 });
+
+      expect(apiClient.glossariesApi.checkGlossaryImportStatus).toHaveBeenCalledTimes(2);
+      expect(apiClient.glossariesApi.checkGlossaryImportStatus).toHaveBeenCalledWith(42, 'import-id');
+    });
+
+    test('throws CliError when the import fails', async () => {
+      spyOn(apiClient.glossariesApi, 'importGlossaryFile').mockResolvedValue({
+        data: { identifier: 'import-id', status: 'failed' },
+      } as never);
+
+      expect(glossaryService.import(42, { storageId: 52 })).rejects.toThrow(new CliError('The import has failed'));
     });
 
     test('wraps API error as CliError', async () => {

--- a/tests/cli/services/TmService.test.ts
+++ b/tests/cli/services/TmService.test.ts
@@ -169,7 +169,9 @@ describe('TmService', () => {
 
   describe('import', () => {
     test('starts the import', async () => {
-      spyOn(apiClient.translationMemoryApi, 'importTm').mockResolvedValue({} as never);
+      spyOn(apiClient.translationMemoryApi, 'importTm').mockResolvedValue({
+        data: { identifier: 'import-id', status: 'finished' },
+      } as never);
 
       await tmService.import(42, { storageId: 52, scheme: { en: 0, uk: 1 }, firstLineContainsHeader: true });
 
@@ -178,6 +180,29 @@ describe('TmService', () => {
         scheme: { en: 0, uk: 1 },
         firstLineContainsHeader: true,
       });
+    });
+
+    test('polls import status until finished', async () => {
+      spyOn(apiClient.translationMemoryApi, 'importTm').mockResolvedValue({
+        data: { identifier: 'import-id', status: 'created', progress: 0 },
+      } as never);
+      spyOn(apiClient.translationMemoryApi, 'checkImportStatus')
+        .mockResolvedValueOnce({ data: { identifier: 'import-id', status: 'inProgress', progress: 50 } } as never)
+        .mockResolvedValueOnce({ data: { identifier: 'import-id', status: 'finished' } } as never);
+      spyOn(Bun, 'sleep').mockResolvedValue(undefined);
+
+      await tmService.import(42, { storageId: 52 });
+
+      expect(apiClient.translationMemoryApi.checkImportStatus).toHaveBeenCalledTimes(2);
+      expect(apiClient.translationMemoryApi.checkImportStatus).toHaveBeenCalledWith(42, 'import-id');
+    });
+
+    test('throws CliError when the import fails', async () => {
+      spyOn(apiClient.translationMemoryApi, 'importTm').mockResolvedValue({
+        data: { identifier: 'import-id', status: 'failed' },
+      } as never);
+
+      expect(tmService.import(42, { storageId: 52 })).rejects.toThrow(new CliError('The import has failed'));
     });
 
     test('wraps API error as CliError', async () => {

--- a/tests/cli/utils/downloadToFile.test.ts
+++ b/tests/cli/utils/downloadToFile.test.ts
@@ -51,13 +51,23 @@ describe('downloadToFile', () => {
   });
 
   // Covers both arms of the mkdir guard the Windows fix added: an existing path is swallowed and
-  // the failure surfaces from the write instead, while any other errno is rethrown as-is.
+  // the failure surfaces from the write instead, while any other errno is rethrown as-is. The errno
+  // itself differs per platform (ENOTDIR on POSIX, ENOENT on Windows), so only its shape is asserted.
   test('swallows EEXIST from mkdir and fails on the write', async () => {
     spyOn(globalThis, 'fetch').mockResolvedValue(new Response('file content'));
     const blocker = join(tempDir, 'blocker');
     await writeFile(blocker, 'not a directory');
 
-    expect(downloadToFile('https://example.test/file.txt', join(blocker, 'file.txt'))).rejects.toThrow(/ENOTDIR/);
+    const error: NodeJS.ErrnoException = await downloadToFile(
+      'https://example.test/file.txt',
+      join(blocker, 'file.txt'),
+    ).then(
+      () => new Error('expected a rejection'),
+      (reason) => reason,
+    );
+
+    expect(error.code).toMatch(/^E/);
+    expect(await Bun.file(blocker).text()).toBe('not a directory');
   });
 
   test('rethrows other mkdir failures', async () => {
@@ -65,9 +75,15 @@ describe('downloadToFile', () => {
     const blocker = join(tempDir, 'blocker');
     await writeFile(blocker, 'not a directory');
 
-    expect(downloadToFile('https://example.test/file.txt', join(blocker, 'nested', 'file.txt'))).rejects.toThrow(
-      /ENOTDIR/,
+    const error: NodeJS.ErrnoException = await downloadToFile(
+      'https://example.test/file.txt',
+      join(blocker, 'nested', 'file.txt'),
+    ).then(
+      () => new Error('expected a rejection'),
+      (reason) => reason,
     );
+
+    expect(error.code).toMatch(/^E/);
   });
 
   test('throws CliError for a failed request', async () => {

--- a/tests/cli/utils/downloadToFile.test.ts
+++ b/tests/cli/utils/downloadToFile.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import CliError from '@/cli/errors/CliError.ts';
+import { downloadToFile } from '@/cli/utils/downloadToFile.ts';
+
+describe('downloadToFile', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'crowdin-download-to-file-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+    mock.restore();
+  });
+
+  test('writes the body to the destination', async () => {
+    spyOn(globalThis, 'fetch').mockResolvedValue(new Response('file content'));
+    const destination = join(tempDir, 'nested', 'file.txt');
+
+    await downloadToFile('https://example.test/file.txt', destination);
+
+    expect(await Bun.file(destination).text()).toBe('file content');
+  });
+
+  test('leaves no part file behind', async () => {
+    spyOn(globalThis, 'fetch').mockResolvedValue(new Response('file content'));
+
+    await downloadToFile('https://example.test/file.txt', join(tempDir, 'file.txt'));
+
+    expect(await readdir(tempDir)).toEqual(['file.txt']);
+  });
+
+  test('throws CliError for a failed request', async () => {
+    spyOn(globalThis, 'fetch').mockResolvedValue(new Response('<Error/>', { status: 403 }));
+
+    expect(downloadToFile('https://example.test/file.txt', join(tempDir, 'file.txt'))).rejects.toThrow(
+      new CliError('Download failed with status 403'),
+    );
+  });
+
+  // A body cut short still ends the stream cleanly, so without the length check the truncated file
+  // would be renamed over a good local one.
+  test('rejects a body shorter than content-length', async () => {
+    spyOn(globalThis, 'fetch').mockResolvedValue(new Response('short', { headers: { 'content-length': '4096' } }));
+
+    expect(downloadToFile('https://example.test/file.txt', join(tempDir, 'file.txt'))).rejects.toThrow(
+      new CliError('Download is incomplete: got 5 of 4096 bytes'),
+    );
+  });
+
+  test('keeps the previous file when the download fails', async () => {
+    const destination = join(tempDir, 'file.txt');
+    await writeFile(destination, 'previous content');
+    spyOn(globalThis, 'fetch').mockResolvedValue(new Response('short', { headers: { 'content-length': '4096' } }));
+
+    await downloadToFile('https://example.test/file.txt', destination).catch(() => {});
+
+    expect(await Bun.file(destination).text()).toBe('previous content');
+    expect(await readdir(tempDir)).toEqual(['file.txt']);
+  });
+});

--- a/tests/cli/utils/downloadToFile.test.ts
+++ b/tests/cli/utils/downloadToFile.test.ts
@@ -50,6 +50,26 @@ describe('downloadToFile', () => {
     expect(await Bun.file(join(tempDir, 'file.txt')).text()).toBe('file content');
   });
 
+  // Covers both arms of the mkdir guard the Windows fix added: an existing path is swallowed and
+  // the failure surfaces from the write instead, while any other errno is rethrown as-is.
+  test('swallows EEXIST from mkdir and fails on the write', async () => {
+    spyOn(globalThis, 'fetch').mockResolvedValue(new Response('file content'));
+    const blocker = join(tempDir, 'blocker');
+    await writeFile(blocker, 'not a directory');
+
+    expect(downloadToFile('https://example.test/file.txt', join(blocker, 'file.txt'))).rejects.toThrow(/ENOTDIR/);
+  });
+
+  test('rethrows other mkdir failures', async () => {
+    spyOn(globalThis, 'fetch').mockResolvedValue(new Response('file content'));
+    const blocker = join(tempDir, 'blocker');
+    await writeFile(blocker, 'not a directory');
+
+    expect(downloadToFile('https://example.test/file.txt', join(blocker, 'nested', 'file.txt'))).rejects.toThrow(
+      /ENOTDIR/,
+    );
+  });
+
   test('throws CliError for a failed request', async () => {
     spyOn(globalThis, 'fetch').mockResolvedValue(new Response('<Error/>', { status: 403 }));
 

--- a/tests/cli/utils/downloadToFile.test.ts
+++ b/tests/cli/utils/downloadToFile.test.ts
@@ -34,6 +34,22 @@ describe('downloadToFile', () => {
     expect(await readdir(tempDir)).toEqual(['file.txt']);
   });
 
+  // Bun on Windows rejects `mkdir('.', { recursive: true })` with EEXIST, which is what a bare
+  // file name resolves to — every relative download failed there.
+  test('writes to a bare file name in the current directory', async () => {
+    spyOn(globalThis, 'fetch').mockResolvedValue(new Response('file content'));
+    const cwd = process.cwd();
+    process.chdir(tempDir);
+
+    try {
+      await downloadToFile('https://example.test/file.txt', 'file.txt');
+    } finally {
+      process.chdir(cwd);
+    }
+
+    expect(await Bun.file(join(tempDir, 'file.txt')).text()).toBe('file content');
+  });
+
   test('throws CliError for a failed request', async () => {
     spyOn(globalThis, 'fetch').mockResolvedValue(new Response('<Error/>', { status: 403 }));
 


### PR DESCRIPTION
## Summary

Four fixes to glossary/TM upload and to every file download in the CLI. The download
one is the notable one: `crowdin tm download` froze on roughly half of all runs, with
no output and no exit code.

## `tm download` froze — `Bun.write(path, response)` never settles

`Bun.write(dest, response)` never settles when the GC collects the `Response` while
the body is still arriving ([oven-sh/bun#40278][1], fixed by [oven-sh/bun#40333][2]
five days after v1.4.0 shipped, so our pinned Bun has the bug and no patch release
carries the fix). The last syntactic use of the `Response` is the `Bun.write` call
itself, so any collection mid-download triggers it. The CLI has no `process.exit`, so
a stalled write means the command simply stops: no file, no error, no exit code.

Nothing about `tm download` is special — a TM export is just the only payload in a
typical project big and slow enough to still be arriving when the GC runs. Measured
chunk arrival:

| download | bytes | chunks | wall | worst gap |
|---|---|---|---|---|
| `tm download --format xlsx` | 151,363 | 10 | 139 ms | 96 ms |
| `tm download` (tmx default) | 1,326,082 | 39 | 552 ms | 106 ms |
| `glossary download` | 974 | 1 | 0 ms | — |
| `file download` | 1,307 | 1 | 0 ms | — |

Single-chunk bodies are complete before the write starts, so there is no window to
collect in. `crowdin download` and `bundle download` have the same profile as TM and
would hang on a large enough project.

All eight download sites now go through one `downloadToFile` helper that streams the
body to disk via node's `pipeline`, plus the guards the inline writes never had:

- bytes land in a sibling `.part` file, renamed over the destination only once the
  whole body arrives — a download that dies halfway no longer replaces a good local
  file with a truncated one
- a short body is rejected against `Content-Length`; a transfer cut mid-flight can
  still end the stream cleanly
- `response.ok` is checked — the signed CDN URLs answer errors with an XML body that
  used to be written out as if it were the requested file
- the `mkdir` each call site repeated

Two tidier-looking spellings are silently wrong on Bun 1.4.0 and are documented in the
helper so nobody "simplifies" into them: `Bun.write(dest, response.body)` writes 23
bytes of `[object ReadableStream]`, and `writeFile(dest, Readable.fromWeb(body))`
inflates binary bodies by ~3% once they arrive in more than one chunk. Both exit 0,
and a single-chunk body hides both.

## Glossary/TM upload reported success for failed imports

Both uploads fired the import and returned. A server-side failure (unparseable file,
bad scheme) arrived after the CLI had already printed `Imported in #N`, so the command
exited 0 and the user learned nothing. The import status is now polled behind a
spinner, the same way the export path already does, and the command fails when the job
does.

The Java CLI is fire-and-forget here too (`GlossaryUploadAction:57`) — a deliberate
divergence: for glossary and TM imports the wait is short and the error reporting is
worth it.

## Glossary/TM upload echoed stale counts

The upload echoed the copy fetched *before* the import, so term and segment counts were
whatever they had been beforehand — `0` for a resource the command had just created,
which reads as "nothing was imported". It is refetched after the import settles, now
that the command waits for one; json and toon carry the corrected object too.

## `glossary list` colors

The glossary line painted the name green and the term count red; the TM line leaves the
name uncolored and paints the count green. Same list shape, two palettes — and red read
as an error next to a glossary that was simply empty. Now identical to `tm list`.

## Notes for reviewers

- The helper's workaround becomes unnecessary on Bun 1.4.1+, but the helper should stay:
  the `ok` check, the atomic rename, the length check and the single seam for all eight
  call sites are worth having regardless of the write primitive underneath.
- Not addressed: no download has a read timeout, so a stalled connection still hangs
  forever. Different failure mode from this one, and a bigger change (a whole-download
  `AbortSignal.timeout` would kill legitimate large builds).
- Zip-extraction writes (`DownloadCommand`, `BundleCommand`) still overwrite local files
  without the temp-then-rename. The bytes are already in memory there, so there is no
  network to die mid-write.

[1]: https://github.com/oven-sh/bun/issues/40278
[2]: https://github.com/oven-sh/bun/pull/40333
