### PR TITLE
ci: run the same biome check in PR and publish gates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 # Hooks must keep LF on Windows checkouts (GitHub runners set core.autocrlf=true): CRLF breaks
 # them under sh, and knip's husky plugin reads the trailing \r as part of the binary name.
 .husky/** text eol=lf
+
+# The biome format gate (bun run lint) requires LF; a CRLF checkout fails it on Windows runners.
+*.ts text eol=lf
+*.js text eol=lf
+*.json text eol=lf

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Lint and format check
-        run: bunx biome check
+        run: bun run lint
 
       - name: Run tests
         run: bun run test

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.10/schema.json",
   "formatter": {
     "enabled": true,
     "indentStyle": "space",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "test:e2e": "bun test e2e/suites/ --timeout 120000",
     "docs": "bun run src-next/scripts/generate-docs.ts",
     "format": "biome format --write",
-    "lint": "biome lint",
-    "check": "biome check --write",
+    "lint": "biome check",
+    "fix": "biome check --write",
     "knip": "knip-bun",
     "prepare": "husky"
   },

--- a/tests/lib/config.test.ts
+++ b/tests/lib/config.test.ts
@@ -211,14 +211,14 @@ describe('ConfigSchema files[] parity fields', () => {
     );
   });
 
-  test.each([
-    '/foo/%file_name%.json',
-    '/foo/**/strings.json',
-  ])('accepts a per-file dest for a patterned source: %p', (dest) => {
-    const config = ConfigSchema.parse({ ...baseConfig({ dest }), preserveHierarchy: true });
+  test.each(['/foo/%file_name%.json', '/foo/**/strings.json'])(
+    'accepts a per-file dest for a patterned source: %p',
+    (dest) => {
+      const config = ConfigSchema.parse({ ...baseConfig({ dest }), preserveHierarchy: true });
 
-    expect(config.files[0]?.dest).toBe(dest);
-  });
+      expect(config.files[0]?.dest).toBe(dest);
+    },
+  );
 
   test('accepts a constant dest when source names a single file', () => {
     const config = ConfigSchema.parse({
@@ -245,12 +245,12 @@ describe('ConfigSchema files[] parity fields', () => {
     expect(config.files[0]?.translation).toBe('/l/**/%locale%/%original_file_name%');
   });
 
-  test.each([
-    '/l/../%locale%/%original_file_name%',
-    '/l/./%locale%/%original_file_name%',
-  ])('rejects a relative path in translation: %p', (translation) => {
-    expect(() => ConfigSchema.parse(baseConfig({ translation }))).toThrow("can't contain any relative paths");
-  });
+  test.each(['/l/../%locale%/%original_file_name%', '/l/./%locale%/%original_file_name%'])(
+    'rejects a relative path in translation: %p',
+    (translation) => {
+      expect(() => ConfigSchema.parse(baseConfig({ translation }))).toThrow("can't contain any relative paths");
+    },
+  );
 
   test('requires a language placeholder when not multilingual', () => {
     expect(() => ConfigSchema.parse(baseConfig({ translation: '/locale/strings.xml' }))).toThrow(


### PR DESCRIPTION
The publish verify job ran `biome check` (lint + format) while the build-test workflow ran `biome lint` only, so the format drift from the biome 2.5.10 bump was first caught at release time. Point both gates at one read-only `lint` script, rename the writing `check` script to `fix`, migrate biome.json to the 2.5.10 schema, and reformat the drifted test.