### PR TITLE
fix(upload): report in-project paths in upload sources output

### DIFF
--- a/src-next/cli/commands/upload/UploadSourcesCommand.ts
+++ b/src-next/cli/commands/upload/UploadSourcesCommand.ts
@@ -204,12 +204,15 @@ export default class UploadSourcesCommand {
       );
     }
 
-    // A machine --output emits the bare sorted source paths (Java DryrunSources plain view) and wins
-    // over --tree; otherwise fall through to the per-file "would be created/updated" messages.
+    // A machine --output emits the bare sorted in-project paths (Java DryrunSources plain view) and
+    // wins over --tree; otherwise fall through to the per-file "would be created/updated" messages.
+    // Paths are the resolved project paths, not the local ones: like Java, a dry run has to show
+    // where the file lands in Crowdin, which `dest` and a stripped common path (preserve_hierarchy:
+    // false) both move away from the repo layout.
     if (
       options.dryrun &&
       printDryRunPaths(
-        toSortedRelativePaths(patternFilePaths.flatMap(({ files }) => files.map(({ localFilePath }) => localFilePath))),
+        toSortedRelativePaths(patternFilePaths.flatMap(({ files }) => files.map(({ projectPath }) => projectPath))),
         options,
         output,
       )
@@ -285,7 +288,7 @@ export default class UploadSourcesCommand {
 
         if (isStringsBasedProject) {
           if (options.dryrun) {
-            output.info(`File '${localFilePath}' would be uploaded`);
+            output.info(`File '${projectPath}' would be uploaded`);
             return;
           }
 
@@ -295,7 +298,7 @@ export default class UploadSourcesCommand {
             checksum = await computeChecksum(localFile);
 
             if (sourceHashes.get(localFilePath) === checksum) {
-              output.info(`File '${localFilePath}' was skipped since it is up to date`);
+              output.info(`File '${projectPath}' was skipped since it is up to date`);
               uploadedSources.push({ path: projectPath, action: 'skipped', reason: 'up to date' });
               return;
             }
@@ -336,13 +339,13 @@ export default class UploadSourcesCommand {
 
         if (existingFile) {
           if (options.autoUpdate === false) {
-            output.info(`File '${localFilePath}' already exists and will not be updated`);
+            output.info(`File '${projectPath}' already exists and will not be updated`);
             uploadedSources.push({ path: projectPath, action: 'skipped', reason: 'auto-update disabled' });
             return;
           }
 
           if (options.dryrun) {
-            output.info(`File '${localFilePath}' would be updated`);
+            output.info(`File '${projectPath}' would be updated`);
             return;
           }
 
@@ -352,7 +355,7 @@ export default class UploadSourcesCommand {
             checksum = await computeChecksum(localFile);
 
             if (sourceHashes.get(localFilePath) === checksum) {
-              output.info(`File '${localFilePath}' was skipped since it is up to date`);
+              output.info(`File '${projectPath}' was skipped since it is up to date`);
               uploadedSources.push({ path: projectPath, action: 'skipped', reason: 'up to date' });
               return;
             }
@@ -406,7 +409,7 @@ export default class UploadSourcesCommand {
         let directoryId: number | undefined;
 
         if (options.dryrun) {
-          output.info(`File '${localFilePath}' would be created`);
+          output.info(`File '${projectPath}' would be created`);
           return;
         }
 

--- a/tests/cli/commands/upload/UploadSourcesCommand.test.ts
+++ b/tests/cli/commands/upload/UploadSourcesCommand.test.ts
@@ -125,6 +125,63 @@ describe('UploadSourcesCommand', () => {
     expect(output.info).toHaveBeenCalledWith("File 'src/app.json' would be created");
   });
 
+  test('dry-run reports the in-project path, not the local one, when preserve_hierarchy is off', async () => {
+    await Bun.$`mkdir -p ${tempDir}/public/locales/en`.quiet();
+    await Bun.write(`${tempDir}/public/locales/en/translation.json`, '{}');
+
+    const output = createOutputMock();
+    const command = createUploadCommand(
+      tempDir,
+      output,
+      baseProjectServiceMock(),
+      { addStorage: mock(async () => ({ data: { id: 10 } })) },
+      baseBranchServiceMock(),
+      baseDirectoryServiceMock(),
+      { ...baseFileServiceMock(), createProjectFile: mock(async () => undefined) },
+      baseLabelServiceMock(),
+      baseTranslationServiceMock(),
+      {
+        source: '/public/locales/en/translation.json',
+        translation: '/public/locales/%two_letters_code%/%original_file_name%',
+      },
+      { preserveHierarchy: false },
+    );
+
+    await command.uploadSourcesAction(commandContext({ dryrun: true }));
+
+    expect(output.info).toHaveBeenCalledWith("File 'translation.json' would be created");
+  });
+
+  test('reports the in-project path for a skipped existing file when preserve_hierarchy is off', async () => {
+    await Bun.$`mkdir -p ${tempDir}/public/locales/en`.quiet();
+    await Bun.write(`${tempDir}/public/locales/en/translation.json`, '{}');
+
+    const output = createOutputMock();
+    const command = createUploadCommand(
+      tempDir,
+      output,
+      baseProjectServiceMock(),
+      { addStorage: mock(async () => ({ data: { id: 10 } })) },
+      baseBranchServiceMock(),
+      baseDirectoryServiceMock(),
+      {
+        ...baseFileServiceMock(),
+        loadProjectFiles: mock(async () => ({ data: [{ data: { id: 77, path: '/translation.json' } }] })),
+      },
+      baseLabelServiceMock(),
+      baseTranslationServiceMock(),
+      {
+        source: '/public/locales/en/translation.json',
+        translation: '/public/locales/%two_letters_code%/%original_file_name%',
+      },
+      { preserveHierarchy: false },
+    );
+
+    await command.uploadSourcesAction(commandContext({ autoUpdate: false }));
+
+    expect(output.info).toHaveBeenCalledWith("File 'translation.json' already exists and will not be updated");
+  });
+
   test('passes merged labels and excluded languages when creating source files', async () => {
     await Bun.write(`${tempDir}/src/app.json`, '{}');
 
@@ -1766,9 +1823,7 @@ describe('UploadSourcesCommand', () => {
       },
     );
 
-    await expect(command.uploadSourcesAction(commandContext({}))).rejects.toThrow(
-      'Current execution finished with errors',
-    );
+    expect(command.uploadSourcesAction(commandContext({}))).rejects.toThrow('Current execution finished with errors');
 
     expect(output.error).toHaveBeenCalledWith(
       "No sources found for '/src/*.json' pattern. Check the source paths in your configuration file",
@@ -1796,7 +1851,7 @@ describe('UploadSourcesCommand', () => {
       { files: [{ source: '/src/*.json', translation: '/locale/%two_letters_code%/%original_file_name%' }] },
     );
 
-    await expect(command.uploadSourcesAction(commandContext({ output: 'plain' }))).rejects.toThrow(
+    expect(command.uploadSourcesAction(commandContext({ output: 'plain' }))).rejects.toThrow(
       'Current execution finished with errors',
     );
 


### PR DESCRIPTION
`upload sources` resolved each source file to its in-project path (common path stripped when `preserve_hierarchy: false`, or `dest` applied) and uploaded it there correctly, but several output messages printed the local repo path instead. With `preserve_hierarchy: false` a dry run claimed it would create `public/locales/en/translation.json` while the real upload put `translation.json` at the project root.

Switch the remaining messages to the resolved project path and the `--output json/plain` summary, which already reported `projectPath`:

- the machine/`--tree` dry-run path listing
- "would be created" / "would be updated" / "would be uploaded"
- "already exists and will not be updated"
- "was skipped since it is up to date"

Upload behaviour is unchanged; only the reported paths were wrong.
