### PR TITLE
fix(distribution): stop the release spinner printing "null%"

### DIFF
--- a/src-next/cli/services/DistributionService.ts
+++ b/src-next/cli/services/DistributionService.ts
@@ -6,7 +6,7 @@ export type DistributionView = DistributionsModel.Distribution;
 
 interface ReleaseStatus {
   status?: string;
-  progress?: number;
+  progress?: number | null;
 }
 
 // The release poll stops on any of these; only "failed" is an error (Java treats success/finished alike).
@@ -76,7 +76,7 @@ export class DistributionService {
     }
 
     while (!RELEASE_TERMINAL_STATUSES.has(release.status?.toLowerCase() ?? '')) {
-      if (release.progress !== undefined) {
+      if (release.progress != null) {
         onProgress?.(release.progress);
       }
 

--- a/tests/cli/services/DistributionService.test.ts
+++ b/tests/cli/services/DistributionService.test.ts
@@ -43,6 +43,25 @@ describe('DistributionService', () => {
       expect(progress).toEqual([20, 60]);
     });
 
+    test('skips the progress callback while the release reports a null progress', async () => {
+      spyOn(apiClient.distributionsApi, 'createDistributionRelease').mockResolvedValue({
+        data: { status: 'inProgress', progress: null },
+      } as never);
+      const statuses = [
+        { data: { status: 'inProgress', progress: null } },
+        { data: { status: 'inProgress', progress: 40 } },
+        { data: { status: 'success', progress: 100 } },
+      ];
+      spyOn(apiClient.distributionsApi, 'getDistributionRelease').mockImplementation(
+        async () => statuses.shift() as never,
+      );
+      const progress: number[] = [];
+
+      await distributionService.releaseDistribution('hash-1', (p) => progress.push(p));
+
+      expect(progress).toEqual([40]);
+    });
+
     test('throws when the release status reports failure', async () => {
       spyOn(apiClient.distributionsApi, 'createDistributionRelease').mockResolvedValue({
         data: { status: 'inProgress', progress: 0 },

--- a/tests/cli/utils/checkVersion.test.ts
+++ b/tests/cli/utils/checkVersion.test.ts
@@ -120,9 +120,11 @@ describe('checkNewVersion', () => {
 
     await checkNewVersion(output, '5.0.0', { cachePath: tmpCachePath() });
 
-    expect(log).not.toHaveBeenCalled();
+    const logged = log.mock.calls.flat().join('\n');
 
     log.mockRestore();
+
+    expect(logged).not.toContain('New version of Crowdin CLI is available!');
   });
 
   test('writes the fetched version to the cache', async () => {


### PR DESCRIPTION
`crowdin distribution release <hash>` printed a progress line reading `Releasing distribution <hash>: null%` on its way to a successful release. 

The poll loop in DistributionService guarded the progress callback with `release.progress !== undefined`, but this endpoint sends `progress: null` while a release is pending. `null !== undefined` is true, so the null reached DistributionCommand's spinner message and rendered as the literal "null%".

Fixed in two places, not one. The guard becomes `!= null`, and ReleaseStatus.progress is widened to `number | null`. With the old `progress?: number`, TypeScript sees `number | undefined`, which makes `!= null` and `!== undefined` look equivalent -- the narrow type is what made the original guard look correct, and leaving it would invite the next reader to simplify the fix straight back out.

The three existing releaseDistribution tests all mocked progress as a number, which is why this survived. Added one that polls null -> null -> 40 -> success and requires the callback to receive [40]. Confirmed it has teeth: with the guard reverted it fails on `[null, null, 40]`.
