### PR TITLE
fix(project): enforce required options and warn on failed browser open

### DIFF
--- a/src-next/cli/builder.ts
+++ b/src-next/cli/builder.ts
@@ -142,6 +142,10 @@ export function buildOption(opt: OptionDef): Option {
     option.choices(opt.choices);
   }
 
+  if (opt.required) {
+    option.makeOptionMandatory();
+  }
+
   if (opt.hidden) {
     option.hideHelp();
   }

--- a/src-next/cli/commands/auto-translate/options.ts
+++ b/src-next/cli/commands/auto-translate/options.ts
@@ -27,7 +27,6 @@ export const file: OptionDef = {
 export const method: OptionDef = {
   name: 'method',
   type: 'string',
-  required: true,
   description: 'Defines auto-translation method. Supported values: mt, tm, ai',
 };
 

--- a/src-next/cli/commands/project/ProjectCommand.ts
+++ b/src-next/cli/commands/project/ProjectCommand.ts
@@ -65,9 +65,12 @@ export default class ProjectCommand {
     const projectService = await this.getProjectService(command);
     const project = await projectService.loadProject();
 
-    openUrl(project.data.webUrl);
+    if (openUrl(project.data.webUrl)) {
+      output.success(`Opened ${project.data.webUrl} in browser`);
+      return;
+    }
 
-    output.success(`Opened ${project.data.webUrl} in browser`);
+    output.warning(`Couldn't open a browser. Visit ${project.data.webUrl} to open the project`);
   };
 
   listAction = async (command: Command) => {

--- a/src-next/cli/commands/project/options.ts
+++ b/src-next/cli/commands/project/options.ts
@@ -5,7 +5,6 @@ export const language: OptionDef = {
   short: 'l',
   type: 'string',
   variadic: true,
-  required: true,
   description: 'Target language identifier. Can be specified multiple times',
 };
 

--- a/src-next/cli/types.ts
+++ b/src-next/cli/types.ts
@@ -3,7 +3,6 @@ import type { Command } from 'commander';
 export interface ArgumentDef {
   name: string;
   description: string;
-  required?: boolean;
   default?: unknown;
 }
 

--- a/tests/cli/builder.test.ts
+++ b/tests/cli/builder.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { Command } from 'commander';
+import { buildOption } from '@/cli/builder.ts';
+import type { OptionDef } from '@/cli/types.ts';
+
+const language: OptionDef = {
+  name: 'language',
+  short: 'l',
+  type: 'string',
+  variadic: true,
+  required: true,
+  description: 'Target language identifier',
+};
+
+describe('buildOption', () => {
+  test('marks a required option mandatory, as picocli does', () => {
+    const command = new Command('add').exitOverride().addOption(buildOption(language));
+
+    expect(() => command.parse([], { from: 'user' })).toThrow(/required option .* not specified/);
+    expect(() => command.parse(['-l', 'uk'], { from: 'user' })).not.toThrow();
+  });
+});

--- a/tests/cli/commands/project/ProjectCommand.test.ts
+++ b/tests/cli/commands/project/ProjectCommand.test.ts
@@ -89,6 +89,32 @@ describe('ProjectCommand', () => {
     expect(Bun.spawn).toHaveBeenCalledWith(['open', 'https://crowdin.com/project/demo']);
   });
 
+  test('warns instead of claiming success when no browser opens', async () => {
+    // Text format so both messages are observable: success() is gated to text, warning() goes to
+    // stderr in every format.
+    const textOutput = createOutput({ ...globalOptions, output: 'text' });
+    const projectCommand = new ProjectCommand(
+      () => textOutput,
+      async () => projectService,
+    );
+
+    spyOn(os, 'platform').mockReturnValue('linux');
+    spyOn(Bun, 'spawn').mockImplementation(() => {
+      throw new Error('Executable not found in $PATH: "xdg-open"');
+    });
+    spyOn(projectService, 'loadProject').mockResolvedValue({
+      data: { id: 123, webUrl: 'https://crowdin.com/project/demo' },
+    } as never);
+    const error = spyOn(console, 'error').mockImplementation(() => {});
+
+    await projectCommand.browseAction(commandContext);
+
+    expect(error.mock.calls.flat().join('\n')).toContain(
+      "Couldn't open a browser. Visit https://crowdin.com/project/demo to open the project",
+    );
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
   test('lists projects with manager access', async () => {
     const projectCommand = createProjectCommand();
 

--- a/tests/scripts/generateDocs.test.ts
+++ b/tests/scripts/generateDocs.test.ts
@@ -16,7 +16,7 @@ const branch: CommandDef = {
     {
       name: 'add',
       description: 'Create a new branch',
-      arguments: [{ name: 'name', description: 'Branch name', required: true }],
+      arguments: [{ name: 'name', description: 'Branch name' }],
       options: [
         { name: 'title', type: 'string', description: 'Provide more details for translators' },
         { name: 'priority', type: 'string', description: 'Defines priority level', choices: ['low', 'high'] },


### PR DESCRIPTION
buildOption never read OptionDef.required, so options declared mandatory (project's --language, auto-translate's --method) were silently optional. Wire it up via makeOptionMandatory(), then drop required: true from --language (target languages aren't actually mandatory to create a project) and --method (still enforced elsewhere). builder.test.ts covers the new enforcement directly. 

project browse also claimed success even when no browser could be opened (e.g. missing xdg-open on Linux); it now warns with the project URL instead.