### PR TITLE
fix(branch): normalize unsupported characters in branch names

### DIFF
--- a/src-next/cli/services/BranchService.ts
+++ b/src-next/cli/services/BranchService.ts
@@ -3,6 +3,7 @@ import { CrowdinValidationError } from '@crowdin/crowdin-api-client';
 import { pollUntilFinished } from '@/lib/api/pollStatus.ts';
 import CliError from '../errors/CliError.ts';
 import { toCliError } from '../errors/toCliError.ts';
+import { normalizeBranchName } from '../utils/parsing.ts';
 
 // Reports each poll's percentage so the command can render its own progress (Java updates a spinner).
 export type ProgressCallback = (progress: number) => void;
@@ -18,6 +19,8 @@ export class BranchService {
       return undefined;
     }
 
+    name = normalizeBranchName(name);
+
     try {
       const branches = await this.apiClient.sourceFilesApi.withFetchAll().listProjectBranches(this.projectId, { name });
       return branches.data.find((branch) => branch.data.name === name)?.data;
@@ -30,6 +33,8 @@ export class BranchService {
     if (!name || name === 'none') {
       return { created: false };
     }
+
+    name = normalizeBranchName(name);
 
     try {
       const branches = await this.apiClient.sourceFilesApi.withFetchAll().listProjectBranches(this.projectId, { name });
@@ -72,7 +77,6 @@ export class BranchService {
   async list(): Promise<SourceFilesModel.Branch[]> {
     try {
       const response = await this.apiClient.sourceFilesApi.withFetchAll().listProjectBranches(this.projectId);
-
       return response.data.map((entry) => entry.data);
     } catch (error) {
       throw toCliError(error, 'Failed to list branches');

--- a/tests/cli/services/BranchService.test.ts
+++ b/tests/cli/services/BranchService.test.ts
@@ -55,6 +55,17 @@ describe('BranchService', () => {
 
       expect(branchService.getBranch('main')).rejects.toThrow(CliError);
     });
+
+    test('normalizes unsupported characters before resolving', async () => {
+      const listSpy = spyOn(apiClient.sourceFilesApi, 'listProjectBranches').mockResolvedValue({
+        data: [{ data: { id: 11, name: 'features.xp-upsell' } }],
+      } as never);
+
+      const result = await branchService.getBranch('features/xp-upsell');
+
+      expect(listSpy).toHaveBeenCalledWith(PROJECT_ID, { name: 'features.xp-upsell' });
+      expect(result).toEqual({ id: 11, name: 'features.xp-upsell' } as never);
+    });
   });
 
   describe('getOrCreateBranch', () => {
@@ -70,13 +81,28 @@ describe('BranchService', () => {
 
     test('returns existing branch when found', async () => {
       spyOn(apiClient.sourceFilesApi, 'listProjectBranches').mockResolvedValue({
-        data: [{ data: { id: 5, name: 'feat/x' } }],
+        data: [{ data: { id: 5, name: 'feat.x' } }],
+      } as never);
+      const createBranch = spyOn(apiClient.sourceFilesApi, 'createBranch');
+
+      const result = await branchService.getOrCreateBranch('feat.x');
+
+      expect(result).toEqual({ branch: { id: 5, name: 'feat.x' }, created: false } as never);
+      expect(createBranch).not.toHaveBeenCalled();
+    });
+
+    // Crowdin rejects '/' in branch names; the CLI normalizes to '.' (as v4 did) so branch
+    // names copy-pasted from GitHub/Bitbucket (e.g. 'features/xp-upsell') work unmodified.
+    test('normalizes unsupported characters before resolving', async () => {
+      const listSpy = spyOn(apiClient.sourceFilesApi, 'listProjectBranches').mockResolvedValue({
+        data: [{ data: { id: 5, name: 'feat.x' } }],
       } as never);
       const createBranch = spyOn(apiClient.sourceFilesApi, 'createBranch');
 
       const result = await branchService.getOrCreateBranch('feat/x');
 
-      expect(result).toEqual({ branch: { id: 5, name: 'feat/x' }, created: false } as never);
+      expect(listSpy).toHaveBeenCalledWith(PROJECT_ID, { name: 'feat.x' });
+      expect(result).toEqual({ branch: { id: 5, name: 'feat.x' }, created: false } as never);
       expect(createBranch).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Crowdin rejects branch names containing `\ / : * ? " < > |`. v4 replaced these with dots client-side so names copy-pasted from GitHub/Bitbucket (e.g. features/xp-upsell) worked unmodified; v5 dropped this, causing "Failed to resolve branch" on any branch name with a slash.

`normalizeBranchName` already existed but was only wired into the branch command. Apply it in `BranchService.getBranch`/`getOrCreateBranch` instead, since every command (upload, download, status, file, string, task, screenshot, context, auto-translate) resolves branches through those two methods.