### PR TITLE
fix(download): exit non-zero when the translations build fails

### DIFF
--- a/src-next/cli/commands/download/DownloadCommand.ts
+++ b/src-next/cli/commands/download/DownloadCommand.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { ProjectsGroupsModel, type ResponseObject, type TranslationsModel } from '@crowdin/crowdin-api-client';
+import { ProjectsGroupsModel, type TranslationsModel } from '@crowdin/crowdin-api-client';
 import AdmZip from 'adm-zip';
 import type { Command } from 'commander';
 import { printDryRunPaths } from '@/cli/commands/common/dryRunPaths.ts';
@@ -396,17 +396,9 @@ export default class DownloadCommand {
           skipUntranslatedFilesUsed = true;
         }
 
-        let build: ResponseObject<TranslationsModel.Build>;
-
-        try {
-          build = group.pseudo
-            ? await translationService.buildProjectTranslations(group.pseudo)
-            : await translationService.buildProjectTranslations(group.request);
-        } catch {
-          // Mirrors Java's ProjectBuildFailedException handling: warn and abort gracefully.
-          output.warning("Didn't manage to build translations");
-          return;
-        }
+        const build = group.pseudo
+          ? await translationService.buildProjectTranslations(group.pseudo)
+          : await translationService.buildProjectTranslations(group.request);
 
         const downloadUrl = await translationService.getTranslationDownloadUrl(build.data.id);
 

--- a/tests/cli/commands/download/DownloadCommand.test.ts
+++ b/tests/cli/commands/download/DownloadCommand.test.ts
@@ -647,7 +647,7 @@ describe('DownloadCommand', () => {
       expect(await savedArchive.exists()).toBe(true);
     });
 
-    test('warns and aborts when translations build fails', async () => {
+    test('rejects when translations build fails', async () => {
       const downloadCommand = createDownloadCommand();
       const buildId = 999;
 
@@ -664,12 +664,10 @@ describe('DownloadCommand', () => {
       spyOn(apiClient.translationsApi, 'checkBuildStatus').mockResolvedValue({
         data: { id: buildId, status: 'failed', progress: 0 },
       } as never);
-      const warningSpy = spyOn(output, 'warning');
 
-      // Build failure warns and aborts gracefully (Java ProjectBuildFailedException parity).
-      await downloadCommand.translationsAction(commandContext);
-
-      expect(warningSpy).toHaveBeenCalledWith("Didn't manage to build translations");
+      // A build failure (or any other build-step error, e.g. a transient 5xx) must propagate and
+      // fail the process (#1102) instead of being swallowed into a warning with a 0 exit code.
+      await expect(downloadCommand.translationsAction(commandContext)).rejects.toThrow('Translations build failed');
     });
   });
 


### PR DESCRIPTION
Fixes #1102.

crowdin download caught any error from the translations build, printed a `Didn't manage to build translations` warning, and returned exit code 0. A transient 504 during the build therefore looked like a successful download to CI, and pipelines went on to deploy untranslated content.

The catch was a mis-port of Java's ProjectBuildFailedException. In DownloadAction.java that exception is only raised when buildTranslation() returns null; real build errors are rethrown by ConsoleSpinner.execute and exit non-zero. The port widened it into a blanket catch around the build call.

Removing the catch is enough — withSpinner already wraps the failure in a CliError with reported = true, and cli.ts maps it to a non-zero exit code. The spinner's error line is still the only message printed; no output changes.

Note: this is a behavior change. Pipelines that were silently passing on a failed download will now fail, which is the point of the fix, but it's worth calling out in the release notes.

Covered by a unit test that asserts translationsAction rejects when the build reports failed.