### PR TITLE
fix: exit non-zero when a command bails without doing its work

### DIFF
--- a/src-next/cli/commands/bundle/BundleCommand.ts
+++ b/src-next/cli/commands/bundle/BundleCommand.ts
@@ -5,6 +5,7 @@ import type { Command } from 'commander';
 import { projectConfigGroup } from '@/cli/commands/common/options.ts';
 import { pathView } from '@/cli/commands/common/views.ts';
 import CliError from '@/cli/errors/CliError.ts';
+import NotFoundError from '@/cli/errors/NotFoundError.ts';
 import type { GlobalOptions } from '@/cli/options.ts';
 import type { AddBundlePayload, BundleView } from '@/cli/services/BundleService.ts';
 import type { GetBundleService, GetConfig, GetLabelService, GetOutput } from '@/cli/services.ts';
@@ -259,11 +260,7 @@ export default class BundleCommand {
     const bundle = await bundleService.get(id);
 
     if (!bundle) {
-      output.warning("Couldn't find bundle by the specified ID");
-      // An early exit still owes the machine formats a document: 'bailed' is carried by the exit
-      // code and the stderr diagnostic, not by an absent stdout, which reads as an empty result.
-      output.list([], pathView);
-      return;
+      throw new NotFoundError("Couldn't find bundle by the specified ID");
     }
 
     // Trigger the export and wait for the server to finish (the service owns the poll).
@@ -287,6 +284,7 @@ export default class BundleCommand {
     const downloadUrl = await bundleService.getDownloadUrl(id, exportId);
 
     await downloadToFile(downloadUrl, archivePath);
+
     output.success(`#${bundle.id} '${bundle.name}' has been successfully downloaded`);
 
     const zip = new AdmZip(archivePath);

--- a/src-next/cli/commands/common/managerAccess.ts
+++ b/src-next/cli/commands/common/managerAccess.ts
@@ -1,0 +1,21 @@
+import ForbiddenError from '@/cli/errors/ForbiddenError.ts';
+import { isMachineFormat } from '@/cli/utils/formatter.ts';
+import type { Output } from '@/cli/utils/output.ts';
+
+const NO_MANAGER_ACCESS = 'You must have manager or developer role in the project to perform this action';
+
+/**
+ * Java branches its `message.no_manager_access` guard on `--plain`; the port widens that to every
+ * machine format, because a warning plus exit 0 reads as an empty result rather than 'you may not
+ * ask' in json and toon just as much as in plain.
+ *
+ * Throws for machine formats — text callers must `return` after calling.
+ */
+export function reportNoManagerAccess(output: Output, format: string | undefined, message = NO_MANAGER_ACCESS): void {
+  if (isMachineFormat(format)) {
+    output.error(message);
+    throw new ForbiddenError(message, true);
+  }
+
+  output.warning(message);
+}

--- a/src-next/cli/commands/download/DownloadCommand.ts
+++ b/src-next/cli/commands/download/DownloadCommand.ts
@@ -5,6 +5,7 @@ import { ProjectsGroupsModel, type TranslationsModel } from '@crowdin/crowdin-ap
 import AdmZip from 'adm-zip';
 import type { Command } from 'commander';
 import { printDryRunPaths } from '@/cli/commands/common/dryRunPaths.ts';
+import { reportNoManagerAccess } from '@/cli/commands/common/managerAccess.ts';
 import { pathView } from '@/cli/commands/common/views.ts';
 import CliError from '@/cli/errors/CliError.ts';
 import { toCliError } from '@/cli/errors/toCliError.ts';
@@ -137,8 +138,8 @@ export default class DownloadCommand {
     // then fetch the project and reject string-based ones.
     if (options.reviewed && !projectService.isEnterprise()) {
       output.warning('Operation is available only for Crowdin Enterprise');
-      // An early exit still owes the machine formats a document: 'bailed' is carried by the exit
-      // code and the stderr diagnostic, not by an absent stdout, which reads as an empty result.
+      // An early exit still owes the machine formats a document; an absent stdout would read as an
+      // empty result either way.
       output.list([], downloadedFileView);
       return;
     }
@@ -295,10 +296,7 @@ export default class DownloadCommand {
     }
 
     if (!hasManagerAccess(project)) {
-      output.warning('You must have manager or developer role in the project to perform this action');
-      // An early exit still owes the machine formats a document: 'bailed' is carried by the exit
-      // code and the stderr diagnostic, not by an absent stdout, which reads as an empty result.
-      output.list([], downloadedFileView);
+      reportNoManagerAccess(output, options.output);
       return;
     }
 

--- a/src-next/cli/commands/file/FileCommand.ts
+++ b/src-next/cli/commands/file/FileCommand.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { ResponseObject, SourceFilesModel, UploadStorageModel } from '@crowdin/crowdin-api-client';
 import { ProjectsGroupsModel } from '@crowdin/crowdin-api-client';
 import type { Command } from 'commander';
+import { reportNoManagerAccess } from '@/cli/commands/common/managerAccess.ts';
 import { branch as branchOption, projectConfigGroup, tree as treeOption } from '@/cli/commands/common/options.ts';
 import CliError from '@/cli/errors/CliError.ts';
 import FileExistsError from '@/cli/errors/FileExistsError.ts';
@@ -348,10 +349,7 @@ export default class FileCommand {
 
     // Manager/developer role is exposed as `languageMapping` only on the settings-bearing response.
     if (!hasManagerAccess(project)) {
-      output.warning('You must have manager or developer role in the project to perform this action');
-      // An early exit still owes the machine formats a document: 'bailed' is carried by the exit
-      // code and the stderr diagnostic, not by an absent stdout, which reads as an empty result.
-      this.reportFiles(output, options, [] as UploadedFile[], uploadedFileView);
+      reportNoManagerAccess(output, options.output);
       return;
     }
 
@@ -609,8 +607,8 @@ export default class FileCommand {
 
     if (project.data.type === ProjectsGroupsModel.Type.STRINGS_BASED) {
       output.warning('File management is not available for string-based projects');
-      // An early exit still owes the machine formats a document: 'bailed' is carried by the exit
-      // code and the stderr diagnostic, not by an absent stdout, which reads as an empty result.
+      // An early exit still owes the machine formats a document; an absent stdout would read as an
+      // empty result either way.
       this.reportDownloaded(output, options, []);
       return;
     }
@@ -664,8 +662,8 @@ export default class FileCommand {
 
     if (project.data.type === ProjectsGroupsModel.Type.STRINGS_BASED) {
       output.warning('File management is not available for string-based projects');
-      // An early exit still owes the machine formats a document: 'bailed' is carried by the exit
-      // code and the stderr diagnostic, not by an absent stdout, which reads as an empty result.
+      // An early exit still owes the machine formats a document; an absent stdout would read as an
+      // empty result either way.
       this.reportDownloaded(output, options, []);
       return;
     }

--- a/src-next/cli/commands/language/LanguageCommand.ts
+++ b/src-next/cli/commands/language/LanguageCommand.ts
@@ -1,5 +1,6 @@
 import type { LanguagesModel, ProjectsGroupsModel } from '@crowdin/crowdin-api-client';
 import type { Command } from 'commander';
+import { reportNoManagerAccess } from '@/cli/commands/common/managerAccess.ts';
 import { projectConfigGroup } from '@/cli/commands/common/options.ts';
 import type { GlobalOptions } from '@/cli/options.ts';
 import { LanguageService } from '@/cli/services/LanguageService.ts';
@@ -95,10 +96,7 @@ export default class LanguageCommand {
 
     // Manager/developer role is exposed as `languageMapping` only on the settings-bearing response.
     if (!hasManagerAccess(project)) {
-      output.warning('You must have manager or developer role in the project to perform this action');
-      // An early exit still owes the machine formats a document: 'bailed' is carried by the exit
-      // code and the stderr diagnostic, not by an absent stdout, which reads as an empty result.
-      output.list([], languageView);
+      reportNoManagerAccess(output, options.output);
       return;
     }
 

--- a/src-next/cli/commands/upload/UploadSourcesCommand.ts
+++ b/src-next/cli/commands/upload/UploadSourcesCommand.ts
@@ -3,6 +3,7 @@ import type { LanguagesModel, SourceFilesModel, SourceStringsModel } from '@crow
 import { ProjectsGroupsModel } from '@crowdin/crowdin-api-client';
 import type { Command } from 'commander';
 import { printDryRunPaths } from '@/cli/commands/common/dryRunPaths.ts';
+import { reportNoManagerAccess } from '@/cli/commands/common/managerAccess.ts';
 import CliError from '@/cli/errors/CliError.ts';
 import FileExistsError from '@/cli/errors/FileExistsError.ts';
 import FileInUpdateError from '@/cli/errors/FileInUpdateError.ts';
@@ -116,10 +117,10 @@ export default class UploadSourcesCommand {
       ({ fileOptions }) => (fileOptions.excluded_target_languages?.length ?? 0) > 0,
     );
 
-    // Java warns and exits 0 by default; its non-zero exit only happened under the removed `--plain`
-    // flag, so this matches Java's default behavior.
     if (!hasManagerAccess(project) && (containsExcludedLanguages || options.deleteObsolete)) {
-      output.warning(
+      reportNoManagerAccess(
+        output,
+        options.output,
         "You must have manager or developer role in the project to apply 'excluded-languages' or/and 'delete-obsolete' options",
       );
       return;

--- a/src-next/cli/commands/upload/UploadTranslationsCommand.ts
+++ b/src-next/cli/commands/upload/UploadTranslationsCommand.ts
@@ -3,6 +3,7 @@ import type { LanguagesModel } from '@crowdin/crowdin-api-client';
 import { ProjectsGroupsModel } from '@crowdin/crowdin-api-client';
 import type { Command } from 'commander';
 import { printDryRunPaths } from '@/cli/commands/common/dryRunPaths.ts';
+import { reportNoManagerAccess } from '@/cli/commands/common/managerAccess.ts';
 import CliError from '@/cli/errors/CliError.ts';
 import WrongLanguageError from '@/cli/errors/WrongLanguageError.ts';
 import type { GlobalOptions } from '@/cli/options.ts';
@@ -72,10 +73,7 @@ export default class UploadTranslationsCommand {
     const project = await projectService.loadProject();
 
     if (!hasManagerAccess(project)) {
-      output.warning('You must have manager or developer role in the project to perform this action');
-      // An early exit still owes the machine formats a document: 'bailed' is carried by the exit
-      // code and the stderr diagnostic, not by an absent stdout, which reads as an empty result.
-      output.list([], uploadedFileView);
+      reportNoManagerAccess(output, options.output);
       return;
     }
 

--- a/tests/cli/commands/bundle/BundleCommand.test.ts
+++ b/tests/cli/commands/bundle/BundleCommand.test.ts
@@ -405,16 +405,15 @@ describe('BundleCommand', () => {
       await rm(tempRoot, { recursive: true, force: true });
     });
 
-    test('warns and skips when bundle is missing', async () => {
-      const textOutput = createOutput(textOptions());
-      const warningSpy = spyOn(textOutput, 'warning');
-      const cmd = createBundleCommand(textOutput);
+    test('fails with a not-found exit code when bundle is missing', async () => {
+      const cmd = createBundleCommand(createOutput(textOptions()));
 
       bundleService.get.mockResolvedValue(null);
 
-      await cmd.downloadAction(createCommandContext(textOptions(), ['5']));
-
-      expect(warningSpy).toHaveBeenCalledWith("Couldn't find bundle by the specified ID");
+      await expect(cmd.downloadAction(createCommandContext(textOptions(), ['5']))).rejects.toMatchObject({
+        message: "Couldn't find bundle by the specified ID",
+        exitCode: 102,
+      });
       expect(bundleService.exportBundle).not.toHaveBeenCalled();
     });
 

--- a/tests/cli/commands/download/DownloadCommand.test.ts
+++ b/tests/cli/commands/download/DownloadCommand.test.ts
@@ -1252,22 +1252,19 @@ describe('DownloadCommand', () => {
       expect(buildProject).not.toHaveBeenCalled();
     });
 
-    test('warns and returns when the user lacks manager access', async () => {
+    test('fails with a forbidden exit code when the user lacks manager access', async () => {
       const downloadCommand = createDownloadCommand();
 
       spyOn(apiClient.projectsGroupsApi, 'getProject').mockResolvedValue({
         data: { id: 123, targetLanguages: [{ id: 'fr' }] },
       } as never);
       const buildProject = spyOn(apiClient.translationsApi, 'buildProject');
-      const warningSpy = spyOn(output, 'warning');
-      const listSpy = spyOn(output, 'list');
+      const errorSpy = spyOn(output, 'error');
 
-      await downloadCommand.translationsAction(commandContext);
-
-      expect(warningSpy).toHaveBeenCalledWith(expect.stringContaining('manager or developer role'));
+      // globalOptions is json, so this takes the machine-format branch.
+      await expect(downloadCommand.translationsAction(commandContext)).rejects.toMatchObject({ exitCode: 103 });
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('manager or developer role'));
       expect(buildProject).not.toHaveBeenCalled();
-      // The bail still owes the machine formats a document, empty though it is.
-      expect(listSpy).toHaveBeenCalledWith([], expect.anything());
     });
 
     test('warns instead of erroring on no files when skip-untranslated-files is set', async () => {

--- a/tests/cli/commands/language/LanguageCommand.test.ts
+++ b/tests/cli/commands/language/LanguageCommand.test.ts
@@ -218,21 +218,17 @@ describe('LanguageCommand', () => {
     );
   });
 
-  test('prints warning and lists nothing if user has no manager access', async () => {
+  test('fails with a forbidden exit code if user has no manager access', async () => {
     const languageCommand = createLanguageCommand();
-    const warning = spyOn(output, 'warning');
-    const list = spyOn(output, 'list');
+    const errorSpy = spyOn(output, 'error');
 
     spyOn(projectService, 'loadProject').mockResolvedValue({ data: {} } as never);
 
-    await languageCommand.listAction(commandContext);
-
-    expect(warning).toHaveBeenCalledWith(
+    // globalOptions is json, so this takes the machine-format branch.
+    await expect(languageCommand.listAction(commandContext)).rejects.toMatchObject({ exitCode: 103 });
+    expect(errorSpy).toHaveBeenCalledWith(
       'You must have manager or developer role in the project to perform this action',
     );
-    // The bail still owes json/toon a document — an absent stdout reads as an empty result, and
-    // 'bailed' is what the exit code and the stderr diagnostic carry.
-    expect(list).toHaveBeenCalledWith([], expect.anything());
   });
 
   test('lists project target languages with plain format outputs only codes', async () => {

--- a/tests/cli/commands/upload/UploadTranslationsCommand.test.ts
+++ b/tests/cli/commands/upload/UploadTranslationsCommand.test.ts
@@ -59,8 +59,6 @@ describe('UploadTranslationsCommand', () => {
       'You must have manager or developer role in the project to perform this action',
     );
     expect(translationService.importProjectTranslation).not.toHaveBeenCalled();
-    // The bail still owes the machine formats a document, empty though it is.
-    expect(output.list).toHaveBeenCalledWith([], expect.anything());
   });
 
   test('soft-matches an existing project file when uploading translations', async () => {


### PR DESCRIPTION
Two commands reported success after refusing to do anything. Both are Java-parity misses in the src-next port, and both bite the same way: a CI pipeline can't tell "nothing to do" from "I wasn't allowed to" or "that ID doesn't exist". Same class as #1102, different paths.

Missing manager/developer access — download translations, upload sources, upload translations, file upload --language and language list printed a warning, emitted an empty result document, and returned exit 0. Java guards these with if (!plainView) { warn; return; } else { throw ForbiddenException; }; the port kept only the warn branch. Restored through a shared reportNoManagerAccess() helper — the five sites were five copies of the same block.

The helper widens Java's --plain condition to every machine format, since json and toon consumers have the same problem plain does. That's the shape ConfigCommand already used for this check; the other sites just never got it.

file download and file download translation still warn and exit 0, matching FileDownloadAction / FileDownloadTranslationAction — Java doesn't throw there either.

Unknown bundle on download — bundle download <bad-id> warned and exited 0. Java has no warning on this path at all: BundleDownloadAction calls getBundle() directly and CrowdinClientCore maps the 404 to a not-found exit. Now throws NotFoundError in every output format. bundle delete and bundle clone keep warning, as Java does.

Also drops a comment repeated at each site claiming the bail "is carried by the exit code" — it wasn't, which is how these got found.

Four existing tests asserted the old behavior and now assert the exit codes (103 / 102) plus the diagnostic. The two json-context tests cover the machine branch, the text-context one keeps the warning, so both branches stay covered without duplicating the same test five times.