### PR TITLE
fix(upload): honour `multilingual: true` when uploading translations

### DIFF
--- a/src-next/cli/commands/upload/UploadTranslationsCommand.ts
+++ b/src-next/cli/commands/upload/UploadTranslationsCommand.ts
@@ -255,8 +255,10 @@ export default class UploadTranslationsCommand {
         }
 
         const firstLanguage = targetLanguages[0];
+        // A file is multilingual via a `scheme` or an explicit `multilingual: true` — the same
+        // rule config.ts applies when it decides a language placeholder is not required.
         const isMultilingual =
-          patterns.scheme !== undefined &&
+          (patterns.scheme !== undefined || patterns.multilingual === true) &&
           firstLanguage !== undefined &&
           !this.translationHasLanguagePlaceholder(patterns.translation);
 

--- a/tests/cli/commands/upload/UploadTranslationsCommand.test.ts
+++ b/tests/cli/commands/upload/UploadTranslationsCommand.test.ts
@@ -1004,6 +1004,56 @@ describe('UploadTranslationsCommand', () => {
     );
   });
 
+  test('uploads one multilingual translation file for all languages when multilingual is set without a scheme', async () => {
+    await Bun.write(`${tempDir}/src/Localizable.xcstrings`, '{}');
+    await Bun.write(`${tempDir}/Localizable.xcstrings`, '{}');
+
+    const storageService = { addStorage: mock(async () => ({ data: { id: 10 } })) };
+    const projectService = {
+      loadProject: mock(async () => ({
+        data: {
+          id: 123,
+          languageMapping: {},
+          targetLanguages: [language('es', 'es', 'spa'), language('fr', 'fr', 'fra')],
+        },
+      })),
+    };
+    const fileService = {
+      ...baseFileServiceMock(),
+      loadProjectFiles: mock(async () => ({
+        data: [{ data: { id: 90, path: '/src/Localizable.xcstrings' } }],
+      })),
+    };
+    const translationService = baseTranslationServiceMock();
+    const command = createUploadCommand(
+      tempDir,
+      createOutputMock(),
+      projectService,
+      storageService,
+      baseBranchServiceMock(),
+      baseDirectoryServiceMock(),
+      fileService,
+      baseLabelServiceMock(),
+      translationService,
+      { source: '/src/*.xcstrings', translation: '/%original_file_name%', multilingual: true },
+      { preserveHierarchy: true },
+    );
+
+    await command.uploadTranslationsAction(commandContext({}));
+
+    expect(translationService.importProjectTranslation).toHaveBeenCalledTimes(1);
+    expect(translationService.importProjectTranslation).toHaveBeenCalledWith(
+      expect.any(Number),
+      90,
+      ['es', 'fr'],
+      'Localizable.xcstrings',
+      undefined,
+      undefined,
+      undefined,
+      expect.any(Function),
+    );
+  });
+
   test('reports an error and continues when a source pattern matches no files during translation upload', async () => {
     const storageService = { addStorage: mock(async () => ({ data: { id: 10 } })) };
     const projectService = {


### PR DESCRIPTION
Fixes #1108.

`UploadTranslationsCommand` recognised only `scheme` when deciding whether a source is multilingual:

```ts
const isMultilingual =
  patterns.scheme !== undefined &&
  firstLanguage !== undefined &&
  !this.translationHasLanguagePlaceholder(patterns.translation);
```

So a source declared `multilingual: true` without a `scheme` fell through to the per-language loop below and was uploaded once per target language instead of once.

`src-next/lib/config.ts` already defines the rule as `file.scheme !== undefined || file.multilingual === true`, and applies it when deciding that a language placeholder is not required. This aligns the upload path with that existing definition rather than introducing a new one.

## Test

Mirrors the existing *"uploads one multilingual translation file for all languages when scheme has no language placeholder"* case, using `multilingual: true` instead of a `scheme`.

It fails on `main` with:

```
expect(received).toHaveBeenCalledTimes(expected)
Expected number of calls: 1
Received number of calls: 2
```

(two target languages in the fixture) and passes with the fix.

Verified locally on bun 1.4.0: the upload suite goes 31 pass / 1 fail → 32 pass / 0 fail, and the full suite gains exactly one passing test with no new failures.
