### PR TITLE
chore(upload): dedupe the multilingual file rule

### DIFF
--- a/src-next/cli/commands/upload/UploadTranslationsCommand.ts
+++ b/src-next/cli/commands/upload/UploadTranslationsCommand.ts
@@ -19,8 +19,8 @@ import { isMachineFormat, isStructuredFormat } from '@/cli/utils/formatter.ts';
 import type { Output } from '@/cli/utils/output.ts';
 import SourceFileLoader from '@/lib/config/SourceFileLoader.ts';
 import { resolveTranslationPath } from '@/lib/config/translationPathResolver.ts';
-import { assertFilesConfigured, type Config } from '@/lib/config.ts';
-import { languagePatterns } from '@/lib/export/patterns.ts';
+import { assertFilesConfigured, type Config, isMultilingualFile } from '@/lib/config.ts';
+import { containsLanguagePlaceholder } from '@/lib/export/languagePlaceholders.ts';
 import { hasManagerAccess } from '@/lib/project/access.ts';
 import { fileLookup } from '@/lib/upload/fileLookup.ts';
 import { getCommonPath, resolveProjectPath } from '@/lib/upload/fileOptions.ts';
@@ -199,8 +199,8 @@ export default class UploadTranslationsCommand {
    * Builds the list of translation uploads from local source files, mirroring Java's
    * UploadTranslationsAction: sources are resolved to project paths (honoring dest /
    * preserve_hierarchy / ignore), and each source expands to one entry per target language —
-   * or a single multi-language entry when a `scheme` is set and the translation pattern has no
-   * language placeholder.
+   * or a single multi-language entry for a multilingual file (a `scheme` or `multilingual: true`)
+   * whose translation pattern has no language placeholder.
    */
   private buildTranslationEntries(
     config: Config,
@@ -255,12 +255,10 @@ export default class UploadTranslationsCommand {
         }
 
         const firstLanguage = targetLanguages[0];
-        // A file is multilingual via a `scheme` or an explicit `multilingual: true` — the same
-        // rule config.ts applies when it decides a language placeholder is not required.
         const isMultilingual =
-          (patterns.scheme !== undefined || patterns.multilingual === true) &&
+          isMultilingualFile(patterns) &&
           firstLanguage !== undefined &&
-          !this.translationHasLanguagePlaceholder(patterns.translation);
+          !containsLanguagePlaceholder(patterns.translation);
 
         if (isMultilingual) {
           const translationPath = stripLeadingSlashes(
@@ -290,10 +288,6 @@ export default class UploadTranslationsCommand {
     }
 
     return { entries, hasErrors };
-  }
-
-  private translationHasLanguagePlaceholder(translation: string): boolean {
-    return languagePatterns.some((pattern) => translation.includes(pattern));
   }
 
   /**

--- a/src-next/lib/config.ts
+++ b/src-next/lib/config.ts
@@ -39,6 +39,14 @@ const coercedBoolean = z.preprocess((value) => {
   return value;
 }, z.boolean());
 
+/**
+ * A file is multilingual via a `scheme` or an explicit `multilingual: true`, the rule Java's
+ * FileBean applies when it decides a language placeholder is not required.
+ */
+export function isMultilingualFile(file: { scheme?: unknown; multilingual?: boolean }): boolean {
+  return file.scheme !== undefined || file.multilingual === true;
+}
+
 export const ConfigSchema = z
   .object({
     // Optional here because the base tier (glossary, tm) talks to the API without a project context,
@@ -52,8 +60,8 @@ export const ConfigSchema = z
         .optional(),
     ),
     // Java only rejects an empty token (BaseProperties: isEmpty → missed_api_token); token length/
-    // validity is the API's job (401), not the config's. A local min-length check wrongly blamed the
-    // config file for a short --token flag, so match Java: reject only empty, let the API judge the rest.
+    // validity is the API's job (401), not the config's - a local min-length check blamed the config
+    // file for a short --token flag.
     apiToken: z.string().min(1, "Required option 'api_token' is missing").optional(),
     basePath: z.string().default('.'),
     baseUrl: z
@@ -104,9 +112,8 @@ export const ConfigSchema = z
             context: z.string().optional(),
             scheme: z.union([z.string(), z.record(z.string(), z.number())]).optional(),
             multilingual: coercedBoolean.optional(),
-            // Parsed for Java config parity but inert (Java reads `multilingual` only; this field is never consumed).
+            // Parsed for Java config parity but inert: Java reads `multilingual` only.
             multilingual_spreadsheet: coercedBoolean.optional(),
-            // Java parity: only the documented config values are accepted, normalized to the API enum.
             update_option: z
               .enum(Object.keys(UPDATE_OPTION_MAP) as [keyof typeof UPDATE_OPTION_MAP])
               .transform((value) => UPDATE_OPTION_MAP[value])
@@ -132,7 +139,7 @@ export const ConfigSchema = z
           // (FileBean.populateWithDefaultValues); every consumer then reads settled values.
           .transform((file) => {
             const translation = collapseSeparators(file.translation);
-            const isMultilingual = file.scheme !== undefined || file.multilingual === true;
+            const isMultilingual = isMultilingualFile(file);
             const hasLanguagePlaceholder = languagePatterns.some((pattern) => translation.includes(pattern));
 
             const normalized = {
@@ -200,13 +207,8 @@ export const ConfigSchema = z
         });
       }
 
-      // A language placeholder is required unless the file is multilingual — either via a `scheme`
-      // or an explicit `multilingual: true` (mirrors Java FileBean.checkProperties).
-      if (
-        file.scheme === undefined &&
-        !file.multilingual &&
-        !languagePatterns.some((pattern) => file.translation.includes(pattern))
-      ) {
+      // Mirrors Java FileBean.checkProperties.
+      if (!isMultilingualFile(file) && !languagePatterns.some((pattern) => file.translation.includes(pattern))) {
         ctx.addIssue({
           code: 'custom',
           message: "The 'translation' parameter should contain at least one language placeholder (e.g. %locale%)",
@@ -238,9 +240,8 @@ export function assertProjectConfigured(config: Config): asserts config is Proje
   }
 }
 
-// `files` is optional in the schema so credential-only commands (project list, browse, etc.) work.
-// File commands (upload/download/config lint) must call this to restore Java's parity error
-// (PropertiesWithFiles.checkProperties -> error.config.empty_or_missed_section_files).
+// File commands (upload/download/config lint) call this to restore Java's parity error, which the
+// optional `files` section drops (PropertiesWithFiles.checkProperties -> empty_or_missed_section_files).
 export function assertFilesConfigured(config: Config): void {
   if (config.files.length === 0) {
     throw new InvalidConfigurationError("Required section 'files' is missing (or empty) in the configuration file");

--- a/tests/cli/commands/upload/UploadTranslationsCommand.test.ts
+++ b/tests/cli/commands/upload/UploadTranslationsCommand.test.ts
@@ -945,7 +945,7 @@ describe('UploadTranslationsCommand', () => {
 
     expect(translationService.importProjectTranslation).toHaveBeenCalledTimes(1);
     expect(translationService.importProjectTranslation).toHaveBeenCalledWith(
-      expect.any(Number),
+      10,
       77,
       ['es'],
       'locale/es/app.json',
@@ -993,7 +993,7 @@ describe('UploadTranslationsCommand', () => {
 
     expect(translationService.importProjectTranslation).toHaveBeenCalledTimes(1);
     expect(translationService.importProjectTranslation).toHaveBeenCalledWith(
-      expect.any(Number),
+      10,
       90,
       ['es', 'fr'],
       'translations.csv',
@@ -1043,7 +1043,7 @@ describe('UploadTranslationsCommand', () => {
 
     expect(translationService.importProjectTranslation).toHaveBeenCalledTimes(1);
     expect(translationService.importProjectTranslation).toHaveBeenCalledWith(
-      expect.any(Number),
+      10,
       90,
       ['es', 'fr'],
       'Localizable.xcstrings',


### PR DESCRIPTION
Follow-up cleanup to #1109. No behavior change.

The `scheme !== undefined || multilingual === true` rule was written out three times — twice in `config.ts`, once in `UploadTranslationsCommand`. That drift is exactly what caused #1109: `config.ts` learned about `multilingual` and the upload copy didn't. Now exported once as `isMultilingualFile()` and called from all three sites.

Also in this PR:
- `UploadTranslationsCommand`'s private `translationHasLanguagePlaceholder` was a byte-for-byte copy of the exported `containsLanguagePlaceholder`; deleted.
- A JSDoc on `buildTranslationEntries` still described the pre-#1109 scheme-only rule.
- Three storage-id assertions used `expect.any(Number)` where the mock returns a fixed `10`. (Left as-is in the one test whose mock increments a counter.)
- Trimmed five comments in `config.ts` that duplicated another comment in the same file or restated the code.
