### PR TITLE
fix(download): send explicit false export options

### DIFF
--- a/src-next/cli/commands/download/DownloadCommand.ts
+++ b/src-next/cli/commands/download/DownloadCommand.ts
@@ -67,10 +67,10 @@ interface SourcesOptions extends GlobalOptions {
 }
 
 interface ExportCombo {
-  skipUntranslatedStrings: boolean;
-  skipUntranslatedFiles: boolean;
-  exportApprovedOnly: boolean;
-  exportStringsThatPassedWorkflow: boolean;
+  skipUntranslatedStrings?: boolean;
+  skipUntranslatedFiles?: boolean;
+  exportApprovedOnly?: boolean;
+  exportStringsThatPassedWorkflow?: boolean;
 }
 
 export default class DownloadCommand {
@@ -521,6 +521,9 @@ export default class DownloadCommand {
    * `distinct()` over the four per-file flags) so each combo is built once and only its own file
    * groups are mapped from that archive. A CLI flag (when set) overrides the per-file config value
    * on every file, forcing `true` — picocli/commander boolean flags can only force true, never false.
+   *
+   * Combo values are tri-state: an unset option is left out of the build request so the project
+   * export settings apply, while an explicit `false` is sent and overrides them.
    */
   private buildExportGroups(
     config: Config,
@@ -560,10 +563,10 @@ export default class DownloadCommand {
     }
 
     const effectiveCombo = (file: Config['files'][number]): ExportCombo => ({
-      skipUntranslatedStrings: options.skipUntranslatedStrings ? true : (file.skip_untranslated_strings ?? false),
-      skipUntranslatedFiles: options.skipUntranslatedFiles ? true : (file.skip_untranslated_files ?? false),
-      exportApprovedOnly: options.exportOnlyApproved ? true : (file.export_only_approved ?? false),
-      exportStringsThatPassedWorkflow: file.export_strings_that_passed_workflow ?? false,
+      skipUntranslatedStrings: options.skipUntranslatedStrings ? true : file.skip_untranslated_strings,
+      skipUntranslatedFiles: options.skipUntranslatedFiles ? true : file.skip_untranslated_files,
+      exportApprovedOnly: options.exportOnlyApproved ? true : file.export_only_approved,
+      exportStringsThatPassedWorkflow: file.export_strings_that_passed_workflow,
     });
 
     // Group files by distinct combo, preserving first-seen order (mirrors Java distinct()).
@@ -592,15 +595,16 @@ export default class DownloadCommand {
         request.targetLanguageIds = resolvedLanguageIds;
       }
 
-      if (combo.skipUntranslatedStrings) {
-        request.skipUntranslatedStrings = true;
+      if (combo.skipUntranslatedStrings !== undefined) {
+        request.skipUntranslatedStrings = combo.skipUntranslatedStrings;
       }
 
-      if (combo.skipUntranslatedFiles) {
-        request.skipUntranslatedFiles = true;
+      if (combo.skipUntranslatedFiles !== undefined) {
+        request.skipUntranslatedFiles = combo.skipUntranslatedFiles;
       }
 
       if (isOrganization) {
+        // Enterprise has no way to force approvals off, so only `true` maps to a request field.
         if (combo.exportApprovedOnly) {
           request.exportWithMinApprovalsCount = 1;
         }
@@ -609,8 +613,8 @@ export default class DownloadCommand {
           request.exportStringsThatPassedWorkflow = true;
         }
       } else {
-        if (combo.exportApprovedOnly) {
-          request.exportApprovedOnly = true;
+        if (combo.exportApprovedOnly !== undefined) {
+          request.exportApprovedOnly = combo.exportApprovedOnly;
         }
 
         if (combo.exportStringsThatPassedWorkflow) {

--- a/tests/cli/commands/download/DownloadCommand.test.ts
+++ b/tests/cli/commands/download/DownloadCommand.test.ts
@@ -1128,6 +1128,103 @@ describe('DownloadCommand', () => {
       expect(apiClient.translationsApi.buildProject).toHaveBeenCalledWith(123, { skipUntranslatedFiles: true });
     });
 
+    test('sends explicit false export options so project settings are overridden', async () => {
+      await Bun.write(join(tempDir, 'resources/en/messages.json'), '{}');
+      mockBuildAndDownload([language('fr', 'fr-FR')]);
+      mockZipEntries([{ entryName: 'resources/fr-FR/messages.json', content: 'translated' }]);
+
+      const downloadCommand = createCommandFor({
+        ...config,
+        files: [
+          {
+            source: '/resources/en/*.json',
+            translation: '/resources/%locale%/%original_file_name%',
+            skip_untranslated_strings: false,
+            skip_untranslated_files: false,
+            export_only_approved: false,
+          },
+        ],
+      });
+
+      await downloadCommand.translationsAction(commandContext);
+
+      expect(apiClient.translationsApi.buildProject).toHaveBeenCalledWith(123, {
+        skipUntranslatedStrings: false,
+        skipUntranslatedFiles: false,
+        exportApprovedOnly: false,
+      });
+    });
+
+    test('omits export options that are not set in the config', async () => {
+      await Bun.write(join(tempDir, 'resources/en/messages.json'), '{}');
+      mockBuildAndDownload([language('fr', 'fr-FR')]);
+      mockZipEntries([{ entryName: 'resources/fr-FR/messages.json', content: 'translated' }]);
+
+      const downloadCommand = createCommandFor({
+        ...config,
+        files: [{ source: '/resources/en/*.json', translation: '/resources/%locale%/%original_file_name%' }],
+      });
+
+      await downloadCommand.translationsAction(commandContext);
+
+      expect(apiClient.translationsApi.buildProject).toHaveBeenCalledWith(123, {});
+    });
+
+    test('keeps an explicit false and an unset option as separate builds', async () => {
+      await Bun.write(join(tempDir, 'resources/en/a.json'), '{}');
+      await Bun.write(join(tempDir, 'resources/en/b.json'), '{}');
+      mockBuildAndDownload([language('fr', 'fr-FR')]);
+      mockZipEntries([
+        { entryName: 'resources/fr-FR/a.json', content: 'a-fr' },
+        { entryName: 'resources/fr-FR/b.json', content: 'b-fr' },
+      ]);
+
+      commandContext = createCommandContext({ ...globalOptions, ignoreMatch: true });
+
+      const downloadCommand = createCommandFor({
+        ...config,
+        files: [
+          {
+            source: '/resources/en/a.json',
+            translation: '/resources/%locale%/%original_file_name%',
+            skip_untranslated_files: false,
+          },
+          {
+            source: '/resources/en/b.json',
+            translation: '/resources/%locale%/%original_file_name%',
+          },
+        ],
+      });
+
+      await downloadCommand.translationsAction(commandContext);
+
+      expect(apiClient.translationsApi.buildProject).toHaveBeenCalledTimes(2);
+      expect(apiClient.translationsApi.buildProject).toHaveBeenCalledWith(123, { skipUntranslatedFiles: false });
+      expect(apiClient.translationsApi.buildProject).toHaveBeenCalledWith(123, {});
+    });
+
+    test('ignores export_only_approved: false on enterprise, which cannot force approvals off', async () => {
+      spyOn(projectService, 'isEnterprise').mockReturnValue(true);
+      await Bun.write(join(tempDir, 'resources/en/messages.json'), '{}');
+      mockBuildAndDownload([language('fr', 'fr-FR')]);
+      mockZipEntries([{ entryName: 'resources/fr-FR/messages.json', content: 'translated' }]);
+
+      const downloadCommand = createCommandFor({
+        ...config,
+        files: [
+          {
+            source: '/resources/en/*.json',
+            translation: '/resources/%locale%/%original_file_name%',
+            export_only_approved: false,
+          },
+        ],
+      });
+
+      await downloadCommand.translationsAction(commandContext);
+
+      expect(apiClient.translationsApi.buildProject).toHaveBeenCalledWith(123, {});
+    });
+
     test('maps export_only_approved to exportWithMinApprovalsCount on enterprise', async () => {
       spyOn(projectService, 'isEnterprise').mockReturnValue(true);
       await Bun.write(join(tempDir, 'resources/en/messages.json'), '{}');


### PR DESCRIPTION
Fixes #1107.

Per-file export options are tri-state, mirroring Java's nullable `Boolean` file beans: unset is omitted from the build request so project export settings apply, an explicit value overrides them.

The port collapsed unset into `false` and then only emitted fields when `true`, so `skip_untranslated_strings: false` (and `skip_untranslated_files`, `export_only_approved`) never reached the API. On a project with the matching setting enabled the build came back empty and the CLI printed `Couldn't find any file to download` with exit code 0.

`exportWithMinApprovalsCount` and `exportStringsThatPassedWorkflow` stay true-only, matching 4.x — Enterprise has no way to force approvals off.

Covered by 4 new cases in `tests/cli/commands/download/DownloadCommand.test.ts`: explicit-false passthrough, unset omission, false-vs-unset as separate builds, and the Enterprise limitation.