### PR TITLE
ci: stage the npm launcher instead of publishing it directly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,11 +119,12 @@ jobs:
       - name: Update npm
         run: npm install -g npm@11.18.0
 
-      - name: Publish
-        run: npm publish packages/npm/cli
+      - name: Stage publish
+        # Staged, not published: the launcher reaches the registry only once a maintainer approves it with 2FA
+        run: npm stage publish packages/npm/cli
 
   assets:
-    # Builds the standalone binaries and creates the GitHub release once the npm packages are published
+    # Builds the standalone binaries and creates the GitHub release once the platform packages are published and the launcher is staged
     needs: publish-cli
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The @crowdin/cli launcher now goes through npm staged publishing: the publish workflow submits the tarball to the staging area and a maintainer approves it with 2FA before it reaches the registry. The platform packages still publish directly - they are inert until the launcher that pins them is live.

Related to: https://github.com/crowdin/crowdin-cli/pull/1025#issuecomment-5525643292