### PR TITLE
fix(scheme): reject an empty column in --scheme

### DIFF
--- a/src-next/cli/utils/parsing.ts
+++ b/src-next/cli/utils/parsing.ts
@@ -70,7 +70,9 @@ export function parseScheme(values: string[]): Record<string, number> | undefine
     const [key, column, ...rest] = value.split('=');
     const index = Number(column);
 
-    if (!key || column === undefined || rest.length > 0 || !Number.isInteger(index) || index < 0) {
+    // `!column`, not `column === undefined`: `Number('')` is 0, so 'en=' would otherwise clear the
+    // integer guard and silently mean column 0 — the first real column.
+    if (!key || !column || rest.length > 0 || !Number.isInteger(index) || index < 0) {
       // Java takes --scheme as Map<String, Integer>, so picocli rejects a malformed value as a
       // usage error (exit 2) rather than a generic failure.
       throw new ValidationError(


### PR DESCRIPTION
`--scheme en=` silently mapped `en` to column 0 — the first real column — instead of erroring, so a typo like `--scheme en=,de=1` mis-mapped the file rather than failing. `Number('')` is `0`, an integer and not negative, so an empty column cleared the validation guard.

Affects `tm upload` and `glossary upload`, the two callers of `parseScheme`. `en=0` still parses — `'0'` is truthy, so widening the check to `!column` doesn't swallow a legitimate first column.

parseScheme's unit tests live on `next_tests` branch.