### PR TITLE
fix(output): always carry the exit code in a json/toon error record

### DIFF
--- a/src-next/cli.ts
+++ b/src-next/cli.ts
@@ -117,7 +117,10 @@ try {
       // --debug: print the full stack trace (message included) instead of the one-liner.
       // ponytail: top-level only; per-file worker-thread stacks stay deferred with upload/download.
       console.error(error.stack);
-    } else if (!(error instanceof CliError && error.reported)) {
+    } else if (isStructured || !(error instanceof CliError && error.reported)) {
+      // `reported` means "already shown to a human" — a spinner line, or a command's own printed
+      // message. json/toon have no such affordance, so the record is always written here, the only
+      // place that knows the exit code.
       output.error(message, { code: exitCode });
     }
 

--- a/src-next/cli/commands/config/ConfigCommand.ts
+++ b/src-next/cli/commands/config/ConfigCommand.ts
@@ -8,7 +8,7 @@ import ValidationError from '@/cli/errors/ValidationError.ts';
 import type { GetConfig, GetLanguageService, GetOutput, GetProjectService } from '@/cli/services.ts';
 import type { CommandDef } from '@/cli/types.ts';
 import { printFileTree } from '@/cli/utils/fileTree.ts';
-import { isMachineFormat } from '@/cli/utils/formatter.ts';
+import { isMachineFormat, isStructuredFormat } from '@/cli/utils/formatter.ts';
 import FileNotFoundError from '@/lib/common/errors/FileNotFoundError.ts';
 import SourceFileLoader from '@/lib/config/SourceFileLoader.ts';
 import { resolveTranslationPath } from '@/lib/config/translationPathResolver.ts';
@@ -101,10 +101,14 @@ export default class ConfigCommand {
       const message = 'You must have manager or developer role in the project to perform this action';
 
       // A machine format owes the caller a result document, and a warning followed by exit 0 reads
-      // as 'no translations' instead of 'you may not ask'. Print first, then throw so the exit code
-      // carries the reason — the same order lintAction uses (Java only branches on --plain here).
+      // as 'no translations' instead of 'you may not ask', so throw to carry the reason in the exit
+      // code (Java only branches on --plain here). plain prints its own record; json/toon get the
+      // handler's.
       if (isMachineFormat(options.output)) {
-        output.error(message);
+        if (!isStructuredFormat(options.output)) {
+          output.error(message);
+        }
+
         throw new ForbiddenError(message, true);
       }
 
@@ -181,7 +185,10 @@ export default class ConfigCommand {
     } catch (error) {
       const message = this.getLintErrorMessage(error);
 
-      output.error(message);
+      // As in the manager-access guard above: json/toon get the handler's record instead.
+      if (!isStructuredFormat(command.optsWithGlobals().output)) {
+        output.error(message);
+      }
 
       // A missing config file is NotFound (102) like Java; invalid content is Validation (2).
       if (error instanceof FileNotFoundError) {

--- a/src-next/cli/utils/output.ts
+++ b/src-next/cli/utils/output.ts
@@ -296,8 +296,12 @@ export function createOutput(options: GlobalOptions, { withGuide = false }: Outp
       message: string,
     ): void {
       if (format !== 'text' || !options.progress) {
+        // Reporting here produced a record with no `code` and, since `withSpinner` marks the error
+        // `reported`, suppressed the handler's record that would have carried one.
         if (operation === 'error') {
-          this.error(message);
+          if (!isStructured) {
+            this.error(message);
+          }
         } else {
           this.info(message);
         }

--- a/tests/cli/commands/config/ConfigCommand.test.ts
+++ b/tests/cli/commands/config/ConfigCommand.test.ts
@@ -351,8 +351,16 @@ describe('ConfigCommand translations', () => {
     const { error, list, thrown } = await run({ data: { targetLanguages: [] } }, { output: format });
 
     expect(thrown).toBeInstanceOf(CliError);
-    expect(error).toHaveBeenCalledWith('You must have manager or developer role in the project to perform this action');
     expect(list).not.toHaveBeenCalled();
+
+    // Only plain prints its own record; json/toon get the top-level handler's.
+    if (format === 'plain') {
+      expect(error).toHaveBeenCalledWith(
+        'You must have manager or developer role in the project to perform this action',
+      );
+    } else {
+      expect(error).not.toHaveBeenCalled();
+    }
   });
 
   test('renders a tree with --tree', async () => {


### PR DESCRIPTION
Whether a structured error record carried `code` depended on which internal path raised the error — invisible to the consumer:

```
config sources --project-id 999999999 --output json
  → {"level":"error","message":"...Project Not Found"}          exit 102

tm download 999999999 --output json
  → {"level":"error","message":"...Tm Not Found","code":102}    exit 102
```

`reported: true` is set in three places — `withSpinner` (11 call sites across six services), `ConfigCommand.lintAction`, and `ConfigCommand`'s manager-access guard. Each printed its own record with no `code`, then threw `reported`, so `cli.ts` skipped the one place that knows the exit code. Paths that never set the flag, like `TmService.get`'s plain try/catch, kept it.

## Change

`reported` now means "already shown to a human" — a spinner line, or a command's own message. json/toon have no such affordance, so the record is written once, by the top-level handler, with `code` attached; the three sites that set the flag stay silent in those formats.

Text and plain are unchanged and still print exactly one line.

## Verified

| command | before | after |
|---|---|---|
| `config sources --project-id 999999999 --output json` | no `code` | `code: 102` |
| `config lint --config /dev/null --output json` | no `code` | `code: 102` |
| `tm download 999999999 --output json` | `code: 102` | `code: 102` |

No double-printing: text still shows one `■ Failed to fetch project info…` line, plain one bare line, toon one record.