### PR TITLE
fix(download): keep downloading sources past a failed file

### DIFF
--- a/src-next/cli/commands/common/failures.ts
+++ b/src-next/cli/commands/common/failures.ts
@@ -1,13 +1,9 @@
 import type { Output } from '@/cli/utils/output.ts';
 
-// Java's UploadSources/UploadTranslations actions run every file, then fail with this generic
-// message if any individual upload errored (error.execution_contains_errors).
+// Java's error.execution_contains_errors: every file is attempted, then the run fails with this if
+// any of them failed.
 export const EXECUTION_FINISHED_WITH_ERRORS = 'Current execution finished with errors';
 
-/**
- * Reports each rejected task (so per-file failures are visible) and returns whether any failed.
- * Mirrors Java, which keeps processing every file and only aggregates the failure at the end.
- */
 export function reportFailures(results: PromiseSettledResult<unknown>[], output: Output): boolean {
   const failures = results.filter((result): result is PromiseRejectedResult => result.status === 'rejected');
 

--- a/src-next/cli/commands/download/DownloadCommand.ts
+++ b/src-next/cli/commands/download/DownloadCommand.ts
@@ -5,6 +5,7 @@ import { ProjectsGroupsModel, type TranslationsModel } from '@crowdin/crowdin-ap
 import AdmZip from 'adm-zip';
 import type { Command } from 'commander';
 import { printDryRunPaths } from '@/cli/commands/common/dryRunPaths.ts';
+import { EXECUTION_FINISHED_WITH_ERRORS, reportFailures } from '@/cli/commands/common/failures.ts';
 import { reportNoManagerAccess } from '@/cli/commands/common/managerAccess.ts';
 import { pathView } from '@/cli/commands/common/views.ts';
 import CliError from '@/cli/errors/CliError.ts';
@@ -30,6 +31,7 @@ import { buildTranslationMapping } from '@/lib/download/translationMapping.ts';
 import { originalPath } from '@/lib/export/patterns.ts';
 import { hasManagerAccess } from '@/lib/project/access.ts';
 import { prepareDest } from '@/lib/upload/fileOptions.ts';
+import { runConcurrently } from '@/lib/utils/concurrency.ts';
 import { stripBranchPrefix, stripLeadingSlashes, toPosixPath, toSortedRelativePaths } from '@/lib/utils/path.ts';
 import { branch, dryRun, filesConfigGroup, tree } from '../common/options.ts';
 import {
@@ -250,31 +252,32 @@ export default class DownloadCommand {
       return;
     }
 
-    for (const download of downloads) {
-      try {
-        const filePath = path.join(config.basePath, download.destination);
-        const downloadUrl = await fileService.getSourceFileDownloadUrl(download.fileId);
+    // Java keeps going past a failed file too, but then exits 0.
+    const results = await runConcurrently(
+      downloads.map((download) => async () => {
+        try {
+          const filePath = path.join(config.basePath, download.destination);
+          const downloadUrl = await fileService.getSourceFileDownloadUrl(download.fileId);
 
-        await downloadToFile(downloadUrl, filePath);
-        output.success(`File '${download.relativePath}'`);
-        downloadedFiles.push({ path: download.relativePath, action: 'downloaded' });
-      } catch (error) {
-        throw toCliError(error, `Failed to download '${download.relativePath}'`);
-      }
-    }
+          await downloadToFile(downloadUrl, filePath);
+          output.success(`File '${download.relativePath}'`);
+          downloadedFiles.push({ path: download.relativePath, action: 'downloaded' });
+        } catch (error) {
+          throw toCliError(error, `Failed to download '${download.relativePath}'`);
+        }
+      }),
+    );
+    const failed = reportFailures(results, output);
 
-    // Text already streamed a line per file, so only the machine formats need the summary.
-    // plain is line-oriented and cannot carry the action, so it lists only what was written.
-    //
-    // No sort here, unlike upload: both loops are sequential over input that is already ordered
-    // by path — collectSourceDownloads sorts its matches, and adm-zip sorts archive entries.
     if (isMachineFormat(options.output)) {
       output.list(
-        isStructuredFormat(options.output)
-          ? downloadedFiles
-          : downloadedFiles.filter(({ action }) => action !== 'skipped'),
+        downloadedFiles.sort((one, other) => one.path.localeCompare(other.path)),
         downloadedFileView,
       );
+    }
+
+    if (failed) {
+      throw new CliError(EXECUTION_FINISHED_WITH_ERRORS);
     }
   };
 
@@ -499,8 +502,7 @@ export default class DownloadCommand {
     // Text already streamed a line per file, so only the machine formats need the summary.
     // plain is line-oriented and cannot carry the action, so it lists only what was written.
     //
-    // No sort here, unlike upload: both loops are sequential over input that is already ordered
-    // by path — collectSourceDownloads sorts its matches, and adm-zip sorts archive entries.
+    // No sort here, unlike sources: this loop is sequential, and adm-zip sorts archive entries.
     if (isMachineFormat(options.output)) {
       output.list(
         isStructuredFormat(options.output)

--- a/src-next/cli/commands/upload/UploadSourcesCommand.ts
+++ b/src-next/cli/commands/upload/UploadSourcesCommand.ts
@@ -3,6 +3,7 @@ import type { LanguagesModel, SourceFilesModel, SourceStringsModel } from '@crow
 import { ProjectsGroupsModel } from '@crowdin/crowdin-api-client';
 import type { Command } from 'commander';
 import { printDryRunPaths } from '@/cli/commands/common/dryRunPaths.ts';
+import { EXECUTION_FINISHED_WITH_ERRORS, reportFailures } from '@/cli/commands/common/failures.ts';
 import { reportNoManagerAccess } from '@/cli/commands/common/managerAccess.ts';
 import CliError from '@/cli/errors/CliError.ts';
 import FileExistsError from '@/cli/errors/FileExistsError.ts';
@@ -45,7 +46,6 @@ import {
   toProjectPath,
   toSortedRelativePaths,
 } from '@/lib/utils/path.ts';
-import { EXECUTION_FINISHED_WITH_ERRORS, reportFailures } from './uploadFailures.ts';
 import { type UploadedFile, uploadedFileView } from './views.ts';
 
 interface UploadSourcesOptions extends GlobalOptions {

--- a/src-next/cli/commands/upload/UploadTranslationsCommand.ts
+++ b/src-next/cli/commands/upload/UploadTranslationsCommand.ts
@@ -3,6 +3,7 @@ import type { LanguagesModel } from '@crowdin/crowdin-api-client';
 import { ProjectsGroupsModel } from '@crowdin/crowdin-api-client';
 import type { Command } from 'commander';
 import { printDryRunPaths } from '@/cli/commands/common/dryRunPaths.ts';
+import { EXECUTION_FINISHED_WITH_ERRORS, reportFailures } from '@/cli/commands/common/failures.ts';
 import { reportNoManagerAccess } from '@/cli/commands/common/managerAccess.ts';
 import CliError from '@/cli/errors/CliError.ts';
 import WrongLanguageError from '@/cli/errors/WrongLanguageError.ts';
@@ -27,7 +28,6 @@ import { fileLookup } from '@/lib/upload/fileLookup.ts';
 import { getCommonPath, resolveProjectPath } from '@/lib/upload/fileOptions.ts';
 import { runConcurrently } from '@/lib/utils/concurrency.ts';
 import { stripBranchPrefix, stripLeadingSlashes, toProjectPath, toSortedRelativePaths } from '@/lib/utils/path.ts';
-import { EXECUTION_FINISHED_WITH_ERRORS, reportFailures } from './uploadFailures.ts';
 import { type UploadedFile, uploadedFileView } from './views.ts';
 
 interface UploadTranslationsOptions extends GlobalOptions {

--- a/tests/cli/commands/download/DownloadCommand.test.ts
+++ b/tests/cli/commands/download/DownloadCommand.test.ts
@@ -1589,20 +1589,34 @@ describe('DownloadCommand', () => {
       );
     });
 
-    test('propagates API errors via toCliError for source download', async () => {
+    test('downloads the remaining sources when one fails, then reports the failure', async () => {
       const downloadCommand = createDownloadCommand();
+      const log = spyOn(console, 'log').mockImplementation(() => {});
+      const error = spyOn(output, 'error');
 
       spyOn(apiClient.projectsGroupsApi, 'getProject').mockResolvedValue({
         data: { id: 123 },
       } as never);
       spyOn(apiClient.sourceFilesApi, 'listProjectFiles').mockResolvedValue({
-        data: [{ data: { id: 1, path: '/resources/en/strings.json' } }],
+        data: [
+          { data: { id: 1, path: '/resources/en/broken.json' } },
+          { data: { id: 2, path: '/resources/en/messages.json' } },
+        ],
       } as never);
-      spyOn(fileService, 'getSourceFileDownloadUrl').mockRejectedValue(new Error('Network error'));
+      spyOn(fileService, 'getSourceFileDownloadUrl').mockImplementation(async (fileId: number) => {
+        if (fileId === 1) {
+          throw new Error('Network error');
+        }
 
-      expect(downloadCommand.sourcesAction(commandContext)).rejects.toThrow(
-        "Failed to download 'resources/en/strings.json'",
-      );
+        return 'https://example.test/messages.json';
+      });
+      spyOn(globalThis, 'fetch').mockResolvedValue(new Response('source content'));
+
+      expect(downloadCommand.sourcesAction(commandContext)).rejects.toThrow('Current execution finished with errors');
+
+      expect(await Bun.file(join(tempDir, 'resources', 'en', 'messages.json')).text()).toBe('source content');
+      expect(error.mock.calls.flat().join('\n')).toContain("Failed to download 'resources/en/broken.json'");
+      expect(log.mock.calls.flat().join('\n')).toContain('resources/en/messages.json');
     });
 
     test('does not download project files that do not match a config pattern', async () => {


### PR DESCRIPTION
## Summary

`download sources` fetched project files one at a time and aborted on the first error. Every file after the failing one went untried, and the files already written were never reported.

It now downloads four files at a time and keeps going when one fails, the same way `upload sources` and `upload translations` already work:

- every failure is printed
- `--output json|toon|plain` still lists the files that were written, sorted by path
- the command then exits 1 with `Current execution finished with errors`

## Behaviour changes

| | Before | After |
|---|---|---|
| Order | one file at a time | 4 concurrent (`runConcurrently`, same limit as upload) |
| One file fails | abort, later files skipped | remaining files still downloaded |
| Exit code on failure | the failing request's own code (102, 103, …) | 1, as upload does |
| Text output order | project path order | completion order |

**Difference from Java.** `DownloadSourcesAction` also runs in parallel and keeps going, but `CrowdinExecutorService.afterExecute` only prints the error and the command exits 0. That part is deliberately not ported. A run that failed to write files should not exit 0, the same reasoning as #1106.

## Changes

- `DownloadCommand.sourcesAction`: the sequential loop is replaced with `runConcurrently` + `reportFailures`, and machine-format output is sorted. The `--reviewed` path is unchanged, since it only extracts from a local archive.
- `reportFailures` / `EXECUTION_FINISHED_WITH_ERRORS` move from `upload/uploadFailures.ts` to `common/failures.ts`, now that download shares them. The two upload imports are updated.
- Fixed a stale comment in `translationsAction` that described the old sequential sources loop.