### PR TITLE
docs(src-next): rewrite porting notes as documentation of current code

### DIFF
--- a/src-next/cli.ts
+++ b/src-next/cli.ts
@@ -84,21 +84,19 @@ async function main(argv: string[], quietErrors: boolean) {
 // file) and the network version check, and keep the raw args intact for the completion protocol.
 const rawArgs = process.argv.slice(2);
 const isCompletion = rawArgs[0] === 'complete';
-// Expand picocli-style @arg-files before commander sees the arguments.
 const argv = [...process.argv.slice(0, 2), ...(isCompletion ? rawArgs : expandArgFiles(rawArgs))];
 const globalOptions = getOutputFormatFromArgs(argv);
 const isStructured = isStructuredFormat(globalOptions.output);
 
 try {
   await main(argv, isStructured);
-  // Mirror Java Cli.main: after a successful real command, check for a newer release. Help, version,
-  // empty args and parse errors all throw CommanderError and land in catch, so they skip the check.
+  // Help, version, empty args and parse errors all throw CommanderError, so they skip the version check.
   if (!isCompletion) {
     await checkNewVersion(createOutput(globalOptions), version);
   }
 } catch (error) {
   // Commander already wrote its own output (help/version to stdout, usage errors to stderr),
-  // so don't reprint. Mirror Java/picocli: help & version exit 0, usage errors exit 2.
+  // so don't reprint. Help and version exit 0, usage errors exit 2.
   if (error instanceof CommanderError) {
     process.exitCode = error.exitCode === 0 ? 0 : 2;
 
@@ -114,8 +112,7 @@ try {
     const exitCode = getExitCode(error);
 
     if (globalOptions.debug && error instanceof Error && error.stack) {
-      // --debug: print the full stack trace (message included) instead of the one-liner.
-      // ponytail: top-level only; per-file worker-thread stacks stay deferred with upload/download.
+      // ponytail: top-level only; per-file failures in upload/download still print just their message.
       console.error(error.stack);
     } else if (isStructured || !(error instanceof CliError && error.reported)) {
       // `reported` means "already shown to a human" — a spinner line, or a command's own printed

--- a/src-next/cli/builder.ts
+++ b/src-next/cli/builder.ts
@@ -48,9 +48,9 @@ export function buildCommand(def: CommandDef): Command {
 
   // A command group runs its default action (usually showing help) when invoked bare, so commander
   // would otherwise treat an unknown subcommand as an excess positional ("too many arguments").
-  // Let the stray token reach the action and report it as an unknown command instead (Java picocli
-  // parity: "Unknown subcommand 'X'"). Guarded by !arguments so a group that ever declares its own
-  // positionals is left to commander's normal argument handling.
+  // Let the stray token reach the action and report it as an unknown command instead. Guarded by
+  // !arguments so a group that ever declares its own positionals is left to commander's normal
+  // argument handling.
   const unknownSubcommandDetected = Boolean(def.subcommands?.length) && !def.arguments?.length;
 
   if (unknownSubcommandDetected) {

--- a/src-next/cli/commands.ts
+++ b/src-next/cli/commands.ts
@@ -47,8 +47,8 @@ import type { CommandDef } from './types.ts';
 const getOutput = createGetOutput();
 const { getConfig, getProjectConfig, tryGetConfig } = createGetConfig(getOutput);
 // The API client needs credentials only, so it takes plain getConfig — that keeps project_id out of
-// the requirements for glossary/tm, which Java runs on BaseProperties. Everything project-scoped
-// takes getProjectConfig, which is where the project_id requirement lives.
+// the requirements for glossary/tm. Everything project-scoped takes getProjectConfig, which is where
+// the project_id requirement lives.
 const getApiClient = createGetApiClient(getConfig);
 const getCommentService = createGetCommentService(getApiClient, getProjectConfig);
 const getAppService = createGetAppService(getApiClient);

--- a/src-next/cli/commands/auto-translate/AutoTranslateCommand.ts
+++ b/src-next/cli/commands/auto-translate/AutoTranslateCommand.ts
@@ -150,7 +150,6 @@ export default class AutoTranslateCommand {
     const { translationModifiedBefore, sourceLanguage: sourceLanguageId } = options;
     const replaceTranslations = this.resolveReplaceTranslationsOption(options.replaceTranslationsOption);
 
-    // Validation order mirrors the Java `checkOptions` method.
     if (directoryPath && files.length > 0) {
       throw new CliError("Either '--file' or '--directory' can be specified");
     }

--- a/src-next/cli/commands/auto-translate/views.ts
+++ b/src-next/cli/commands/auto-translate/views.ts
@@ -4,8 +4,8 @@ import type { View } from '@/cli/utils/output.ts';
  * The outcome of one pre-translation run. Unlike upload and download this command writes no
  * files, so its result is the job itself plus, under `--verbose`, the totals from its report.
  *
- * Text prints those totals as indented lines and nothing at all without `--verbose`; json and
- * toon otherwise saw an empty stdout for a command that had translated the project.
+ * Text prints those totals as indented lines, and nothing at all without `--verbose`, so this is
+ * all json and toon get.
  */
 export interface AutoTranslateResult {
   identifier: string;
@@ -20,8 +20,7 @@ export interface AutoTranslateResult {
  * Without `--verbose` the report is never fetched, so only the job itself can be reported.
  *
  * plain falls back to this line, so it carries the identifier alone even under `--verbose` —
- * the totals are a structured report and belong in json/toon. Java prints all four counts under
- * `--plain`, but that branch has no plainView case, the same omission as its error handler.
+ * the totals are a structured report and belong in json/toon.
  */
 export const autoTranslateView: View<AutoTranslateResult> = {
   text: (result) => result.identifier,

--- a/src-next/cli/commands/branch/options.ts
+++ b/src-next/cli/commands/branch/options.ts
@@ -3,8 +3,7 @@ import type { OptionDef } from '@/cli/types.ts';
 
 const BRANCH_PRIORITIES: SourceFilesModel.Priority[] = ['low', 'normal', 'high'];
 
-// add/edit both take --title and --priority but with different wording
-// (Java crowdin.branch.<sub>.*), so grouped per subcommand.
+// add/edit both take --title and --priority but with different wording, so grouped per subcommand.
 
 export const add = {
   title: {

--- a/src-next/cli/commands/branch/views.ts
+++ b/src-next/cli/commands/branch/views.ts
@@ -3,7 +3,7 @@ import { colors } from '@/cli/utils/colors.ts';
 import type { View } from '@/cli/utils/output.ts';
 import { stripLeadingSlashes } from '@/lib/utils/path.ts';
 
-// Java message.branch.list, shared by list and every mutation echo (BranchAddAction et al.).
+// Shared by list and every mutation echo.
 export const branchView: View<SourceFilesModel.Branch> = {
   text: (branch) => `${colors.yellow(`#${branch.id}`)} ${colors.green(stripLeadingSlashes(branch.name))}`,
   plain: (branch) => stripLeadingSlashes(branch.name),
@@ -12,8 +12,7 @@ export const branchView: View<SourceFilesModel.Branch> = {
 
 export type MergeSummaryRow = { targetBranchId: number } & SourceFilesModel.MergeBranchSummary['details'];
 
-// Java message.branch.merge plus message.branch.merge_details on the next line; plain prints the
-// target branch id alone (BranchMergeAction).
+// The merge line plus its summary on the next; plain prints the target branch id alone.
 export const mergeView = (source: string, target: string): View<MergeSummaryRow> => ({
   text: ({ targetBranchId: _targetBranchId, ...details }) => {
     const summary = Object.entries(details)

--- a/src-next/cli/commands/bundle/BundleCommand.ts
+++ b/src-next/cli/commands/bundle/BundleCommand.ts
@@ -48,8 +48,7 @@ interface BundleOptions extends GlobalOptions {
   dryrun?: boolean;
 }
 
-// Java message.bundle.list: id, format, export pattern, name. Shared by list and the add/clone
-// echoes; Java's plain echo prints the id alone, but keeping the listing shape retains the name.
+// Shared by list and the add/clone echoes, so the plain echo keeps the name next to the id.
 const bundleView: View<BundleView> = {
   text: (bundle) =>
     `${colors.yellow(`#${bundle.id}`)} ${colors.green(bundle.format ?? '')} ${colors.red(
@@ -60,7 +59,7 @@ const bundleView: View<BundleView> = {
 };
 
 // The kept archive is a file the command wrote, so it belongs in the result: plain prints the bare
-// path (what Java's --plain branch meant to print), json/toon serialize it, text keeps the sentence.
+// path, json/toon serialize it, text keeps the sentence.
 const archiveView: View<string> = {
   text: (archivePath) => `Archive saved to '${archivePath}'`,
   plain: (archivePath) => archivePath,
@@ -263,7 +262,6 @@ export default class BundleCommand {
       throw new NotFoundError("Couldn't find bundle by the specified ID");
     }
 
-    // Trigger the export and wait for the server to finish (the service owns the poll).
     output.spinner('bundle-build', 'start', 'Building bundle');
 
     let exportId: string;
@@ -291,9 +289,9 @@ export default class BundleCommand {
     const entries = zip.getEntries().filter((entry) => !entry.isDirectory);
 
     // Unlike `download`, which only ever uses archive entry names as lookup keys, this writes them
-    // to disk. AdmZip's getData()/Bun.write pair does no containment checking of its own — Java gets
-    // that from zip4j — so an entry named `../…` would land outside basePath. Checked before the
-    // dry-run branch too, so a dry run reports the same bad archive instead of looking clean.
+    // to disk. AdmZip's getData()/Bun.write pair does no containment checking of its own, so an entry
+    // named `../…` would land outside basePath. Checked before the dry-run branch too, so a dry run
+    // reports the same bad archive instead of looking clean.
     const extractions = entries.map((entry) => {
       const relativePath = stripLeadingSlashes(toPosixPath(entry.entryName));
       const targetPath = path.join(config.basePath, relativePath);
@@ -313,9 +311,8 @@ export default class BundleCommand {
       }
     }
 
-    // Java prints one path per extracted file (message.file_path), for a dry run as much as for a
-    // real one. Both used to go through log()/success(), so json/toon/plain — where the path list
-    // is the whole result — printed nothing at all.
+    // One path per extracted file, for a dry run as much as for a real one. In json/toon/plain the
+    // path list is the whole result.
     const extractedPaths = extractions.map(({ relativePath }) => relativePath);
 
     if (isMachineFormat(options.output)) {
@@ -327,9 +324,8 @@ export default class BundleCommand {
     }
 
     if (options.keepArchive) {
-      // log() is text-only, so the plain branch this replaces printed nothing at all, and json/toon
-      // lost the path with it. item() renders the view in every format — and those formats report
-      // POSIX paths on every OS, so path.join's separators are normalized.
+      // item(), not log(), so every format gets the path — and the machine formats report POSIX
+      // paths on every OS, so path.join's separators are normalized.
       output.item(toPosixPath(archivePath), archiveView);
     } else {
       try {

--- a/src-next/cli/commands/comment/CommentCommand.ts
+++ b/src-next/cli/commands/comment/CommentCommand.ts
@@ -117,8 +117,7 @@ export default class CommentCommand {
     let type = options.type as StringCommentsModel.Type | undefined;
 
     // Both filters only exist on issues, and the API rejects either one on its own with "Any of
-    // [type] must be set". Java infers the type for --status (CommentListAction); --issue-type
-    // needs it for the same reason.
+    // [type] must be set", so the type is inferred.
     if ((status || options.issueType) && !type) {
       type = 'issue';
     }
@@ -141,8 +140,8 @@ export default class CommentCommand {
     const comment = await commentService.resolve(id);
 
     output.success(`A string issue #${comment.id} has been successfully resolved`);
-    // Text keeps Java's sentence; the machine formats get the resolved comment itself, as the add
-    // echo above already does.
+    // Text keeps the sentence; the machine formats get the resolved comment itself, as the add echo
+    // does.
     output.item(comment, commentView, { mark: false });
   };
 }

--- a/src-next/cli/commands/comment/options.ts
+++ b/src-next/cli/commands/comment/options.ts
@@ -1,7 +1,7 @@
 import type { OptionDef } from '@/cli/types.ts';
 
-// `list` describes --type/--issue-type as filters (Java crowdin.comment.list.*), while `add`
-// describes them as setters. Grouped per subcommand so each flag's wording sits together.
+// `list` describes --type/--issue-type as filters, while `add` describes them as setters. Grouped
+// per subcommand so each flag's wording sits together.
 // --string-id is shared verbatim, so it stays a single const referenced by both.
 const stringId: OptionDef = {
   name: 'string-id',

--- a/src-next/cli/commands/comment/views.ts
+++ b/src-next/cli/commands/comment/views.ts
@@ -3,14 +3,14 @@ import { toSingleLine } from '@/cli/commands/common/views.ts';
 import { colors } from '@/cli/utils/colors.ts';
 import type { View } from '@/cli/utils/output.ts';
 
-// Java message.comment.list, shared by list and the add echo (CommentAddAction).
+// Shared by list and the add echo.
 export const commentView: View<StringCommentsModel.StringComment> = {
   text: (comment) => `${colors.yellow(`#${comment.id}`)} ${colors.green(toSingleLine(comment.text))}`,
   plain: (comment) => String(comment.id),
   keys: ['id', 'text'],
 };
 
-// message.comment.list.verbose adds language, issue type and lower-cased issue status.
+// The verbose line adds language, issue type and lower-cased issue status.
 export const commentVerboseView: View<StringCommentsModel.StringComment> = {
   text: (comment) =>
     `${colors.yellow(`#${comment.id}`)} ${colors.green(toSingleLine(comment.text))} ${colors.red(

--- a/src-next/cli/commands/common/dryRunPaths.ts
+++ b/src-next/cli/commands/common/dryRunPaths.ts
@@ -13,19 +13,15 @@ export interface DryRunListingOptions {
  *
  * A machine `--output` (json/toon/plain) is a parseable contract, so it wins over `--tree` and
  * goes through `output.list`: a path per line in plain, the array in json/toon. `printFileTree`
- * and bare lines both go through `output.log`, which is text-only — checking for `plain` alone,
- * as three of these call sites used to, left `--output=json` and `--output=toon` printing nothing.
+ * goes through `output.log`, which is text-only.
  *
  * Returns false when neither applies, so a caller that has its own non-listing dry-run output
  * (the per-file "would be created" messages) can carry on.
  *
- * `paths` arrive prepared — slash-stripped and sorted via toSortedRelativePaths. Callers that also
- * print the listing themselves in text need them in that shape anyway, so normalizing here too
- * just did the work twice.
+ * `paths` arrive prepared — slash-stripped and sorted via toSortedRelativePaths — because callers
+ * that also print the listing themselves in text need them in that shape anyway.
  */
 export function printDryRunPaths(paths: string[], options: DryRunListingOptions, output: Output): boolean {
-  // The format check stays: in text the caller prints its own messages instead, and it needs to
-  // know the listing wasn't emitted.
   if (isMachineFormat(options.output)) {
     output.list(paths, pathView);
     return true;

--- a/src-next/cli/commands/common/failures.ts
+++ b/src-next/cli/commands/common/failures.ts
@@ -1,7 +1,6 @@
 import type { Output } from '@/cli/utils/output.ts';
 
-// Java's error.execution_contains_errors: every file is attempted, then the run fails with this if
-// any of them failed.
+// Every file is attempted, then the run fails with this if any of them failed.
 export const EXECUTION_FINISHED_WITH_ERRORS = 'Current execution finished with errors';
 
 export function reportFailures(results: PromiseSettledResult<unknown>[], output: Output): boolean {

--- a/src-next/cli/commands/common/managerAccess.ts
+++ b/src-next/cli/commands/common/managerAccess.ts
@@ -5,9 +5,8 @@ import type { Output } from '@/cli/utils/output.ts';
 const NO_MANAGER_ACCESS = 'You must have manager or developer role in the project to perform this action';
 
 /**
- * Java branches its `message.no_manager_access` guard on `--plain`; the port widens that to every
- * machine format, because a warning plus exit 0 reads as an empty result rather than 'you may not
- * ask' in json and toon just as much as in plain.
+ * Every machine format fails the run, because a warning plus exit 0 reads as an empty result
+ * rather than 'you may not ask'.
  *
  * Throws for machine formats — text callers must `return` after calling.
  */

--- a/src-next/cli/commands/common/options.ts
+++ b/src-next/cli/commands/common/options.ts
@@ -42,7 +42,7 @@ export const translation: OptionDef = {
   description: 'Path to the translation files',
 };
 
-// Config-option `--dest` for file-based commands (Java ParamsWithFiles.destParam: long-only, no `-d`).
+// Config-option `--dest` for file-based commands (long-only, no `-d`).
 // Distinct from init's `--destination` (which saves the config skeleton, defaulting to crowdin.yml):
 // here it overrides the in-project file destination, so it must have no default — otherwise the value
 // would always override the configured `dest`.
@@ -65,7 +65,7 @@ export const noPreserveHierarchy: OptionDef = {
 };
 
 export const dryRun: OptionDef = {
-  // Matches the Java CLI flag spelling (`--dryrun`); Commander exposes it as `options.dryrun`.
+  // One word, the spelling existing scripts use; Commander exposes it as `options.dryrun`.
   name: 'dryrun',
   type: 'boolean',
   description: 'Print a command output without execution',
@@ -86,8 +86,7 @@ export const branch: OptionDef = {
   description: 'Specify branch name',
 };
 
-// Config option tiers, mirroring the Java picocli param tiers (BaseParams -> ProjectParams -> ParamsWithFiles).
-// Each tier is defined once here so a command never drifts from its expected option set.
+// Config option tiers, each defined once here so a command never drifts from its expected option set.
 const baseConfigOptions = [token, baseUrl, basePath];
 const projectConfigOptions = [...baseConfigOptions, projectId];
 const filesConfigOptions = [
@@ -99,11 +98,11 @@ const filesConfigOptions = [
   noPreserveHierarchy,
 ];
 
-// BaseParams: commands that talk to the API without a project context (tm, glossary).
+// Commands that talk to the API without a project context (tm, glossary).
 export const baseConfigGroup: OptionGroupDef = { group: 'Config options:', options: baseConfigOptions };
 
-// ProjectParams: project-scoped commands (branch, file, string, task, ...).
+// Project-scoped commands (branch, file, string, task, ...).
 export const projectConfigGroup: OptionGroupDef = { group: 'Config options:', options: projectConfigOptions };
 
-// ParamsWithFiles: file-based commands (upload, download, auto-translate, config).
+// File-based commands (upload, download, auto-translate, config).
 export const filesConfigGroup: OptionGroupDef = { group: 'Config options:', options: filesConfigOptions };

--- a/src-next/cli/commands/common/views.ts
+++ b/src-next/cli/commands/common/views.ts
@@ -1,15 +1,15 @@
 import type { View } from '@/cli/utils/output.ts';
 
-// Java Dryrun.run prints one path per line (message.file_path is a bare '%s'). Shared by the
-// config listings and the dry-run path listings, whose items are the paths themselves.
+// One path per line. Shared by the config listings and the dry-run path listings, whose items are
+// the paths themselves.
 export const pathView: View<string> = {
   text: (path) => path,
   plain: (path) => path,
 };
 
-// Java message.downloaded_file ('%s' downloaded successfully): glossary and tm both echo the file
-// they wrote. plain prints the bare path — the only place a script can learn it, since the default
-// target is derived from the entity's name ('%name%.tbx') and never echoed anywhere else.
+// glossary and tm both echo the file they wrote. plain prints the bare path — the only place a
+// script can learn it, since the default target is derived from the entity's name ('%name%.tbx')
+// and never echoed anywhere else.
 export const downloadedPathView: View<string> = {
   text: (writtenPath) => `'${writtenPath}' downloaded successfully`,
   plain: (writtenPath) => writtenPath,

--- a/src-next/cli/commands/config/ConfigCommand.ts
+++ b/src-next/cli/commands/config/ConfigCommand.ts
@@ -66,8 +66,8 @@ export default class ConfigCommand {
     await projectService.loadProject();
     const localFilePaths = new SourceFileLoader(config).getFilePaths();
 
-    // With preserve_hierarchy off, Java's DryrunSources strips the files' common parent directory so
-    // the listing shows paths relative to it; with it on, the full hierarchy is kept.
+    // With preserve_hierarchy off, the files' common parent directory is stripped so the listing
+    // shows paths relative to it; with it on, the full hierarchy is kept.
     const prefix = config.preserveHierarchy ? '' : getCommonPath(localFilePaths);
     const displayedPaths = localFilePaths
       .map((localFilePath) => (localFilePath.startsWith(prefix) ? localFilePath.slice(prefix.length) : localFilePath))
@@ -95,15 +95,13 @@ export default class ConfigCommand {
 
     const project = await projectService.loadProject();
 
-    // Only managers/developers get a ProjectSettings response, so its presence is the access probe
-    // (mirrors Java ListTranslationsAction's isManagerAccess guard).
+    // Only managers/developers get a ProjectSettings response, so its presence is the access probe.
     if (!('translateDuplicates' in project.data)) {
       const message = 'You must have manager or developer role in the project to perform this action';
 
       // A machine format owes the caller a result document, and a warning followed by exit 0 reads
       // as 'no translations' instead of 'you may not ask', so throw to carry the reason in the exit
-      // code (Java only branches on --plain here). plain prints its own record; json/toon get the
-      // handler's.
+      // code. plain prints its own record; json/toon get the handler's.
       if (isMachineFormat(options.output)) {
         if (!isStructuredFormat(options.output)) {
           output.error(message);
@@ -116,8 +114,6 @@ export default class ConfigCommand {
       return;
     }
 
-    // Server-side language mapping and the in-context pseudo-language come from project settings,
-    // matching Java's getLanguageMapping() + getProjectLanguages(withInContextLang=true).
     const settings = project.data;
     const serverLanguageMapping = settings.languageMapping;
     const languages = [...settings.targetLanguages];
@@ -129,9 +125,9 @@ export default class ConfigCommand {
     const sourceFileLoader = new SourceFileLoader(config);
     const translationFilePaths = new Set<string>();
 
-    // Java DryrunTranslations.getFiles flat-maps over the file groups, resolving each group's own
-    // sources against that group's `translation`, then de-duplicates. Iterating the deduped union of
-    // sources instead would collapse a file matched by two groups into whichever group came first.
+    // Each group resolves its own sources against its own `translation`, then the results are
+    // de-duplicated. Iterating the deduped union of sources instead would collapse a file matched by
+    // two groups into whichever group came first.
     for (const patterns of config.files) {
       // biome-ignore format: manual formatting looks better
       const sourceFilePaths = sourceFileLoader.getFilePathsForPattern(
@@ -190,7 +186,7 @@ export default class ConfigCommand {
         output.error(message);
       }
 
-      // A missing config file is NotFound (102) like Java; invalid content is Validation (2).
+      // A missing config file is NotFound (102); invalid content is Validation (2).
       if (error instanceof FileNotFoundError) {
         throw new NotFoundError(message, true);
       }
@@ -199,8 +195,7 @@ export default class ConfigCommand {
     }
   };
 
-  // Lint-only check: every `source` pattern must match at least one file on disk
-  // (mirrors Java PropertiesWithFiles.checkSourceFilesExist, gated to CheckType.LINT).
+  // Lint-only check: every `source` pattern must match at least one file on disk.
   private checkSourceFilesExist(config: Config): void {
     const loader = new SourceFileLoader(config);
 
@@ -213,8 +208,7 @@ export default class ConfigCommand {
     }
   }
 
-  // Lint-only check: every `languages_mapping` source-language key must be a real Crowdin language id
-  // (mirrors Java PropertiesWithFiles.checkProperties, which validates against listSupportedLanguages).
+  // Lint-only check: every `languages_mapping` source-language key must be a real Crowdin language id.
   private async validateLanguagesMapping(config: Config, command: Command): Promise<void> {
     const filesWithMapping = config.files.filter((file) => file.languages_mapping);
     if (filesWithMapping.length === 0) {

--- a/src-next/cli/commands/context/ContextCommand.ts
+++ b/src-next/cli/commands/context/ContextCommand.ts
@@ -240,7 +240,7 @@ export default class ContextCommand {
     }));
 
     // Nothing to patch — the run is already over, so say so instead of exiting silently. Checked
-    // ahead of the dry run, which was just as silent on an empty file.
+    // ahead of the dry run so an empty file says so there too.
     if (changes.length === 0) {
       output.list(changes, contextChangeView(), {
         empty:
@@ -437,10 +437,8 @@ export default class ContextCommand {
     let strings: SourceStringsModel.String[] = [];
 
     if (!isStringsBased && fileFilters.length > 0) {
-      // A file filter that matches nothing yields no strings. The Java CLI
-      // falls back to all project strings for 'status' and 'reset' in that
-      // case — an intentional divergence: silently widening the scope of a
-      // destructive 'reset' to the whole project is unsafe.
+      // A file filter that matches nothing yields no strings rather than falling back to all of
+      // them: silently widening a destructive 'reset' to the whole project is unsafe.
       // Matched against the branch-relative path: a '--file' glob never carries a branch, the same
       // as everywhere else in the CLI.
       const fileIds = [...filePaths.entries()]
@@ -466,10 +464,10 @@ export default class ContextCommand {
   }
 
   /**
-   * A line that holds no record fails the read, rather than being skipped as the Java CLI skips it:
-   * both callers rewrite the file they read, so a dropped line is an upload that silently sends
-   * less than the file holds, or a download that recomputes the ai_context that line carried and
-   * then overwrites it. Nothing parsed at all means the file is not a context file to begin with —
+   * A line that holds no record fails the read rather than being skipped: both callers rewrite the
+   * file they read, so a dropped line is an upload that silently sends less than the file holds, or
+   * a download that recomputes the ai_context that line carried and then overwrites it. Nothing
+   * parsed at all means the file is not a context file to begin with —
    * a glossary, an XLIFF — which is worth saying instead of pointing at its first line.
    */
   private async readContextRecords(filePath: string): Promise<StringContextRecord[]> {
@@ -549,7 +547,7 @@ export default class ContextCommand {
     const withAi = strings.filter((entry) => getAiContextSection(entry.context) !== '').length;
     const withManual = strings.filter((entry) => getManualContext(entry.context) !== '').length;
     const withoutAi = total - withAi;
-    // No strings at all means no percentage to report; dividing anyway printed 'NaN'.
+    // No strings at all means no percentage to report; dividing anyway would print 'NaN'.
     const percentage = (value: number) => (total === 0 ? '0.00' : ((value / total) * 100).toFixed(2));
 
     return {

--- a/src-next/cli/commands/context/options.ts
+++ b/src-next/cli/commands/context/options.ts
@@ -40,8 +40,8 @@ export const byFile: OptionDef = {
   description: 'Break down stats per file',
 };
 
-// download + status share the same string-filter set; reset uses its own wording
-// (Java crowdin.context.reset.*). Grouped so each flag's wording sits together.
+// download + status share the same string-filter set; reset uses its own wording. Grouped so each
+// flag's wording sits together.
 export const filter = {
   file: {
     name: 'file',

--- a/src-next/cli/commands/context/views.ts
+++ b/src-next/cli/commands/context/views.ts
@@ -24,7 +24,7 @@ export interface ContextChange {
 }
 
 /**
- * The per-string line upload and reset print. `suffix` carries Java's conditional wording ('would
+ * The per-string line upload and reset print. `suffix` carries the conditional wording ('would
  * be uploaded'), so a real run reuses the same view without it. plain prints the id alone, as the
  * string listing does — a text and a context both run to arbitrary length and hold newlines.
  */
@@ -34,7 +34,7 @@ export const contextChangeView = (suffix = ''): View<ContextChange> => ({
   keys: ['id', 'text', 'context'],
 });
 
-/** The file `context download` wrote. Java's message.saved; the path is the whole result. */
+/** The file `context download` wrote; the path is the whole result. */
 export const savedPathView: View<string> = {
   text: (writtenPath) => `'${writtenPath}' saved successfully`,
   plain: (writtenPath) => writtenPath,

--- a/src-next/cli/commands/distribution/DistributionCommand.ts
+++ b/src-next/cli/commands/distribution/DistributionCommand.ts
@@ -15,8 +15,8 @@ interface DistributionOptions extends GlobalOptions {
   bundleId?: number | string | Array<number | string>;
 }
 
-// Java message.distribution.list: hash, name, export mode. Java's add/edit echoes drop to the name
-// alone in plain view; we keep the listing's shape so the hash — what `release`/`edit` take — stays.
+// Shared by list and the add/edit echoes, so the plain echo keeps the hash that `release`/`edit`
+// take.
 const distributionView: View<DistributionsModel.Distribution> = {
   text: (distribution) =>
     `${colors.yellow(distribution.hash)} ${distribution.name ?? ''} ${colors.blue(distribution.exportMode ?? '')}`,

--- a/src-next/cli/commands/download/DownloadCommand.ts
+++ b/src-next/cli/commands/download/DownloadCommand.ts
@@ -136,8 +136,6 @@ export default class DownloadCommand {
 
     assertFilesConfigured(config);
 
-    // Java order (DownloadSourcesAction): reviewed/enterprise guard, then preserve_hierarchy warning,
-    // then fetch the project and reject string-based ones.
     if (options.reviewed && !projectService.isEnterprise()) {
       output.warning('Operation is available only for Crowdin Enterprise');
       // An early exit still owes the machine formats a document; an absent stdout would read as an
@@ -170,7 +168,6 @@ export default class DownloadCommand {
     );
 
     if (options.dryrun) {
-      // Java Dryrun: slash-strip + sort the paths; plain view prints them bare (no icon/message).
       const paths = toSortedRelativePaths(downloads.map((download) => download.relativePath));
 
       if (!printDryRunPaths(paths, options, output)) {
@@ -192,7 +189,7 @@ export default class DownloadCommand {
         await downloadToFile(downloadUrl, archivePath);
 
         // The reviewed archive nests every file under a `<source_language_id>-REV` directory;
-        // strip that prefix so keys line up with the project file paths (mirrors Java).
+        // strip that prefix so keys line up with the project file paths.
         const prefix = `${project.data.sourceLanguageId}-REV`;
         const reviewedFiles = new Map<string, Uint8Array>();
         const zip = new AdmZip(archivePath);
@@ -252,7 +249,6 @@ export default class DownloadCommand {
       return;
     }
 
-    // Java keeps going past a failed file too, but then exits 0.
     const results = await runConcurrently(
       downloads.map((download) => async () => {
         try {
@@ -303,8 +299,6 @@ export default class DownloadCommand {
       return;
     }
 
-    // Java validates/downloads against getProjectLanguages(true) = target languages + the in-context
-    // pseudo language (when the project has one), not just the target languages.
     const inContextPseudoLanguage =
       'inContextPseudoLanguage' in project.data ? project.data.inContextPseudoLanguage : undefined;
     const projectLanguages = inContextPseudoLanguage
@@ -321,11 +315,9 @@ export default class DownloadCommand {
     const branchId = branch?.id;
 
     if (options.dryrun) {
-      // Java lists the resolved translation destination paths (per source x language), not the raw
-      // server source paths (ListTranslationsAction -> DryrunTranslations). Reuse the same mapping
-      // the real download uses; its values are exactly those local destination paths.
-      // Java's ListTranslationsAction always loads the full server file map (independent of --all) so it
-      // can drop target languages excluded server-side per file (DryrunTranslations.containsExcludedLanguage).
+      // Lists the local destination paths (per source × language), not the server source paths:
+      // they are exactly the values of the mapping the real download uses. The server file map is
+      // loaded even without --all, to drop the target languages a file excludes server-side.
       const projectFiles = this.stripBranchFromPaths((await fileService.loadProjectFiles(branchId)).data, branch?.name);
       const serverSourcePaths = options.all
         ? projectFiles.map((file) => stripLeadingSlashes(file.data.path || ''))
@@ -356,7 +348,6 @@ export default class DownloadCommand {
 
     const isOrganization = projectService.isEnterprise();
 
-    // Both skip flags together is invalid (Java params-level check, mirroring the per-file schema rule).
     if (options.skipUntranslatedStrings && options.skipUntranslatedFiles) {
       throw new CliError(
         'You cannot skip strings and files at the same time. Please use one of these parameters instead.',
@@ -386,7 +377,7 @@ export default class DownloadCommand {
 
     const tempDirs: string[] = [];
     const downloadedFiles: DownloadedFile[] = [];
-    // One omitted-entry list per build; reported as the cross-build intersection (Java totalOmittedFiles).
+    // One omitted-entry list per build; reported as the cross-build intersection.
     const perBuildOmitted: string[][] = [];
     let anyFileDownloaded = false;
     let skipUntranslatedFilesUsed = projectSkipUntranslatedFiles;
@@ -409,7 +400,7 @@ export default class DownloadCommand {
 
         await downloadToFile(downloadUrl, archivePath);
 
-        // Pseudo builds always map all target languages (Java ignores export_languages/exclude here).
+        // Pseudo builds map every project language, ignoring export_languages and --exclude-language.
         const mappingLanguages = group.pseudo ? projectLanguages : resolvedLanguages;
         const mapping = buildTranslationMapping(config, mappingLanguages, serverLanguageMapping, {
           useServerSources: options.all,
@@ -427,7 +418,6 @@ export default class DownloadCommand {
           const archiveRelPath = stripLeadingSlashes(toPosixPath(entry.entryName));
           const localPath = mapping.byArchivePath.get(archiveRelPath);
 
-          // Entries with no config mapping are "omitted" and reported below.
           if (!localPath) {
             omittedFiles.push(archiveRelPath);
             downloadedFiles.push({
@@ -458,8 +448,7 @@ export default class DownloadCommand {
 
           output.success(`Archive saved to '${savedArchivePath}'`);
           // The kept archive is a file this run wrote, so it joins the summary the machine formats
-          // render below. success() is text-only, and without this the path — the whole point of
-          // --keep-archive — was missing from json/toon/plain entirely.
+          // render below; success() is text-only.
           downloadedFiles.push({ path: name, action: 'downloaded' });
         }
       }
@@ -517,10 +506,9 @@ export default class DownloadCommand {
 
   /**
    * Builds the list of translation builds to issue. `pseudo` always produces a single all-files
-   * build. Otherwise files are grouped by their effective export-option combo (mirroring Java's
-   * `distinct()` over the four per-file flags) so each combo is built once and only its own file
-   * groups are mapped from that archive. A CLI flag (when set) overrides the per-file config value
-   * on every file, forcing `true` — picocli/commander boolean flags can only force true, never false.
+   * build. Otherwise files are grouped by their effective export-option combo so each combo is
+   * built once and only its own file groups are mapped from that archive. A CLI flag, when set,
+   * forces `true` on every file over the per-file config value; a boolean flag cannot force false.
    *
    * Combo values are tri-state: an unset option is left out of the build request so the project
    * export settings apply, while an explicit `false` is sent and overrides them.
@@ -569,7 +557,7 @@ export default class DownloadCommand {
       exportStringsThatPassedWorkflow: file.export_strings_that_passed_workflow,
     });
 
-    // Group files by distinct combo, preserving first-seen order (mirrors Java distinct()).
+    // Group files by distinct combo, in first-seen order.
     const groups = new Map<string, { combo: ExportCombo; files: Config['files'] }>();
 
     for (const file of config.files) {
@@ -628,9 +616,9 @@ export default class DownloadCommand {
 
   /**
    * Reports omitted archive entries across all builds. With multiple builds (one per export-option
-   * combo), Java reports only files omitted in EVERY build: per-source translation lists are
-   * intersected and the without-source list is intersected (mirrors Java's totalOmittedFiles
-   * retainAll). A source absent from any build's omitted set contributes an empty intersection.
+   * combo), only files omitted in EVERY build are reported: the per-source translation lists and the
+   * without-source list are each intersected. A source absent from any build's omitted set
+   * contributes an empty intersection.
    */
   private reportOmittedFiles(
     perBuildOmitted: string[][],
@@ -710,10 +698,8 @@ export default class DownloadCommand {
   /**
    * Drops the branch name that files inside a branch carry in their project path
    * ('/dev/src/en.json' -> '/src/en.json'). Every config-derived path is branch-relative, so without
-   * this nothing matches once `--branch` is given. Java scopes the file list to the branch and then
-   * builds paths from the directory tree alone (ProjectFilesUtils.buildDirectoryPaths without
-   * branches); stripping once at the load boundary is the same thing, and keeps every consumer below
-   * comparing plain project-relative paths.
+   * this nothing matches once `--branch` is given. Stripping once at the load boundary keeps every
+   * consumer below comparing plain project-relative paths.
    */
   private stripBranchFromPaths<T extends { data: { path?: string } }>(files: T[], branchName?: string): T[] {
     if (!branchName) {
@@ -727,12 +713,10 @@ export default class DownloadCommand {
   }
 
   /**
-   * Resolves which project source files should be downloaded for `download sources`, scoping each
-   * config group to files matching its `dest ?? source` pattern (mirroring Java's
-   * DownloadSourcesAction filtering). With manager access the file's export pattern must also be
-   * compatible with the group `translation`. Files matching the group `ignore` patterns are dropped
-   * (mirrors SourcesUtils.filterProjectFiles' ignore predicate). Each matched file's destination
-   * applies `dest`.
+   * Resolves which project source files `download sources` fetches, scoping each config group to
+   * files matching its `dest ?? source` pattern. With manager access the file's export pattern must
+   * also be compatible with the group `translation`. Files matching the group `ignore` patterns are
+   * dropped. Each matched file's destination applies `dest`.
    */
   private collectSourceDownloads(
     config: Config,
@@ -790,11 +774,11 @@ export default class DownloadCommand {
   }
 
   /**
-   * Computes a source file's local destination, mirroring Java DownloadSourcesAction. With no `dest`
-   * the file keeps its project path. With `dest`: when `dest` has neither `**` nor `%original_path%`
-   * and `source` has `**`, the `dest` pattern is applied directly; otherwise the destination is
-   * derived from the `source` pattern via `replaceUnaryAsterisk` (substituting the real file
-   * segments) — both then resolve file-dependent placeholders.
+   * Computes a source file's local destination. With no `dest` the file keeps its project path.
+   * With `dest`: when `dest` has neither `**` nor `%original_path%` and `source` has `**`, the `dest`
+   * pattern is applied directly; otherwise the destination is derived from the `source` pattern via
+   * `replaceUnaryAsterisk` (substituting the real file segments) — both then resolve file-dependent
+   * placeholders.
    */
   private resolveSourceDestination(patterns: Config['files'][number], relativePath: string): string {
     if (!patterns.dest) {
@@ -809,7 +793,7 @@ export default class DownloadCommand {
   }
 
   // Maps each server source path (basePath-relative posix, no leading slash) to its excluded target
-  // languages, so the dry-run listing can skip those languages per file (Java parity).
+  // languages, so the dry-run listing can skip those languages per file.
   private buildExcludedTargetLanguagesByPath(
     projectFiles: { data: { path?: string; excludedTargetLanguages?: string[] } }[],
   ): Map<string, string[]> {

--- a/src-next/cli/commands/download/views.ts
+++ b/src-next/cli/commands/download/views.ts
@@ -2,8 +2,7 @@ import type { View } from '@/cli/utils/output.ts';
 
 /**
  * What became of one downloaded file. Text output streams its own per-file messages as the
- * download runs; this is the summary json/toon get instead, since `output.success` is text-only
- * and those formats otherwise saw an empty stdout for a command that wrote real files to disk.
+ * download runs; this is the summary json/toon get instead, since `output.success` is text-only.
  *
  * Kept separate from upload's UploadedFile despite the identical shape: the action vocabularies
  * differ, and merging them would give each command a union naming outcomes it can never produce.
@@ -19,7 +18,7 @@ export interface DownloadedFile {
 export const downloadedFileView: View<DownloadedFile> = {
   // text streams its own per-file messages and never renders this list.
   text: (file) => file.path,
-  // Java's Dryrun plain view prints bare paths, one per line; the real run matches it.
+  // Bare paths, one per line, the same as the dry-run listing.
   plain: (file) => file.path,
   keys: ['path', 'action', 'reason'],
 };

--- a/src-next/cli/commands/file/FileCommand.ts
+++ b/src-next/cli/commands/file/FileCommand.ts
@@ -148,8 +148,7 @@ export default class FileCommand {
     await projectService.loadProject();
     const branchId = await branchService.resolveBranchId(options.branch);
     // loadProjectFiles is already scoped to the branch (root tree without one), so without
-    // '--branch' a project whose files all live in branches lists nothing at all — as Java's
-    // FileListAction does.
+    // '--branch' a project whose files all live in branches lists nothing at all.
     const projectFiles = await fileService.loadProjectFiles(branchId);
     // Paths inside a branch come back prefixed with the branch name; the listing shows project paths.
     const files = projectFiles.data.map((file) => ({
@@ -333,7 +332,7 @@ export default class FileCommand {
     }
   };
 
-  // Upload path when `--language` is set: import translations for the file (Java FileUploadTranslationAction).
+  // Upload path when `--language` is set: import translations for the file.
   private uploadTranslation = async (
     command: Command,
     options: UploadFileCommandOptions,
@@ -360,8 +359,8 @@ export default class FileCommand {
     const isStringsBased = project.data.type === ProjectsGroupsModel.Type.STRINGS_BASED;
     const storage = await this.uploadToStorage(storageService, localFile, filePath);
 
-    // Java passes the percent message unconditionally here (unlike upload translations, where it is
-    // verbose-only), and appends the identifier only under --verbose.
+    // The percent message is unconditional here (unlike upload translations, where it is
+    // verbose-only); the identifier is appended only under --verbose.
     const onProgress: ImportProgress = (status) =>
       output.log(
         `Importing translations for file '${filePath}' (${status.progress}%)` +
@@ -403,7 +402,7 @@ export default class FileCommand {
   };
 
   // The non-xliff import: file-based needs the project file the translation belongs to,
-  // strings-based needs the branch (Java FileUploadTranslationAction's two else-branches).
+  // strings-based needs the branch.
   private importFileTranslation = async (
     command: Command,
     options: UploadFileCommandOptions,
@@ -458,8 +457,7 @@ export default class FileCommand {
     );
   };
 
-  // Source upload for strings-based projects: branch is mandatory; upload + poll to completion
-  // (Java FileUploadAction strings-based path).
+  // Source upload for strings-based projects: branch is mandatory; upload + poll to completion.
   private uploadStringsBased = async (
     command: Command,
     filePath: string,
@@ -497,8 +495,8 @@ export default class FileCommand {
   /**
    * The summary the machine formats get for a command whose text output is a stream of per-file
    * messages — the same {path, action} entries `upload sources` and `download` emit, so a script
-   * parses one shape whichever command wrote the file. success() prints in text only, so without
-   * this a real upload or download left json/toon/plain with an empty stdout.
+   * parses one shape whichever command wrote the file. success() prints in text only, so this is
+   * all json/toon/plain get.
    */
   private reportUploaded(output: Output, options: GlobalOptions, file: UploadedFile): void {
     this.reportFiles(output, options, [file], uploadedFileView);
@@ -647,7 +645,7 @@ export default class FileCommand {
     throw new CliError(`File '${filePath}' not found in the Crowdin project`);
   };
 
-  // Download path when `--language` is set: build and save file translations (Java FileDownloadTranslationAction).
+  // Download path when `--language` is set: build and save file translations.
   private downloadTranslation = async (
     command: Command,
     options: UploadFileCommandOptions,
@@ -662,8 +660,6 @@ export default class FileCommand {
 
     if (project.data.type === ProjectsGroupsModel.Type.STRINGS_BASED) {
       output.warning('File management is not available for string-based projects');
-      // An early exit still owes the machine formats a document; an absent stdout would read as an
-      // empty result either way.
       this.reportDownloaded(output, options, []);
       return;
     }

--- a/src-next/cli/commands/file/options.ts
+++ b/src-next/cli/commands/file/options.ts
@@ -1,7 +1,7 @@
 import type { OptionDef } from '@/cli/types.ts';
 
-// upload/download both take --dest but with different wording (Java crowdin.file.<sub>.dest),
-// so grouped per subcommand to keep each flag's wording together.
+// upload/download both take --dest but with different wording, so grouped per subcommand to keep
+// each flag's wording together.
 
 export const upload = {
   label: {

--- a/src-next/cli/commands/file/views.ts
+++ b/src-next/cli/commands/file/views.ts
@@ -3,22 +3,18 @@ import { colors } from '@/cli/utils/colors.ts';
 import type { View } from '@/cli/utils/output.ts';
 import { stripLeadingSlashes } from '@/lib/utils/path.ts';
 
-// Java strips leading slashes from displayed paths (FileListAction).
 const displayPath = (file: SourceFilesModel.File): string => stripLeadingSlashes(file.path);
 
 function hasRevisionInfo(file: SourceFilesModel.File): boolean {
   return file.parserVersion !== undefined && file.revisionId !== undefined;
 }
 
-// Java message.file.list.
 export const fileView: View<SourceFilesModel.File> = {
   text: (file) => `${colors.yellow(`#${file.id}`)} ${colors.green(displayPath(file))}`,
   plain: (file) => `${file.id} ${displayPath(file)}`,
   keys: ['id', 'path'],
 };
 
-// Verbose splits on whether the entry carries parser/revision data, as Java splits on
-// FileInfo vs File: list_verbose_full when it does, list_verbose when it doesn't.
 export const fileVerboseView: View<SourceFilesModel.File> = {
   text: (file) => {
     const head = `${colors.yellow(`#${file.id}`)} ${colors.green(displayPath(file))} ${file.type}`;

--- a/src-next/cli/commands/global/options.ts
+++ b/src-next/cli/commands/global/options.ts
@@ -43,7 +43,7 @@ export const output: OptionDef = {
   choices: ['json', 'toon', 'plain'],
 };
 
-// Hidden: prints full stack traces instead of the one-line error message (ports Java GenericCommand --debug).
+// Hidden: prints full stack traces instead of the one-line error message.
 export const debug: OptionDef = {
   name: 'debug',
   type: 'boolean',

--- a/src-next/cli/commands/glossary/views.ts
+++ b/src-next/cli/commands/glossary/views.ts
@@ -7,9 +7,9 @@ const termLine = (term: GlossariesModel.Term): string =>
   `\t${colors.yellow(`#${term.id}`)} ${colors.green(term.text)}: ${toSingleLine(term.description ?? '')}`;
 
 /**
- * Java GlossaryListAction: one line per glossary and, when verbose, its terms indented underneath.
- * Terms come from a per-glossary request the command makes up front, so they are passed in.
- * Plain prints the name alone and never lists terms, as Java keeps that block inside !plainView.
+ * One line per glossary and, when verbose, its terms indented underneath. Terms come from a
+ * per-glossary request the command makes up front, so they are passed in. Plain prints the name
+ * alone and never lists terms.
  */
 export function createGlossaryView({
   verbose = false,

--- a/src-next/cli/commands/init/browserAuthServer.ts
+++ b/src-next/cli/commands/init/browserAuthServer.ts
@@ -4,7 +4,7 @@ import CliError from '@/cli/errors/CliError.ts';
 const CROWDIN_OAUTH_CLIENT_ID = 'wQEqvhU3vLOa2XicmUyT';
 const CROWDIN_OAUTH_HOST = 'localhost';
 const CROWDIN_OAUTH_PORT = 46221;
-const AUTHORIZATION_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
+const AUTHORIZATION_TIMEOUT_MS = 2 * 60 * 1000;
 
 export interface BrowserAuthorization {
   accessToken: string;

--- a/src-next/cli/commands/label/LabelCommand.ts
+++ b/src-next/cli/commands/label/LabelCommand.ts
@@ -8,15 +8,14 @@ import type { CommandDef } from '@/cli/types.ts';
 import { colors } from '@/cli/utils/colors.ts';
 import type { View } from '@/cli/utils/output.ts';
 
-// Java message.label.list, shared by list and the add echo (LabelAddAction).
+// Shared by list and the add echo.
 const labelView: View<LabelsModel.Label> = {
   text: (label) => `${colors.yellow(`#${label.id}`)} ${colors.green(label.title)}`,
   plain: (label) => label.title,
   keys: ['id', 'title'],
 };
 
-// Java LabelListAction prints the decorated line when `!plainView || isVerbose`, so a verbose
-// plain listing carries the ids too.
+// A verbose plain listing prints the decorated line, so it carries the ids too.
 const labelVerboseView: View<LabelsModel.Label> = {
   text: labelView.text,
   plain: labelView.text,

--- a/src-next/cli/commands/language/LanguageCommand.ts
+++ b/src-next/cli/commands/language/LanguageCommand.ts
@@ -29,7 +29,6 @@ interface LanguageCommandOptions extends GlobalOptions {
 // language: json consumers have no way to reproduce the mapping overrides on their own.
 type ResolvedLanguage = LanguagesModel.Language & { code: string };
 
-// Java message.language.list: resolved code, name.
 const languageView: View<ResolvedLanguage> = {
   text: (language) => `${colors.yellow(language.code)} ${colors.green(language.name ?? '')}`,
   plain: (language) => language.code,

--- a/src-next/cli/commands/project/ProjectCommand.ts
+++ b/src-next/cli/commands/project/ProjectCommand.ts
@@ -98,9 +98,8 @@ export default class ProjectCommand {
 
     const sourceLanguageId = options.sourceLanguage || 'en';
     const targetLanguageIds = options.language ?? [];
-    // No `identifier`: the API generates one from the name, and a name with a space or any other
-    // character the identifier rules reject ('CLI 27') made the request fail outright. Java never
-    // sends one either.
+    // No `identifier`: the API generates one from the name, whereas a name with a space or any other
+    // character the identifier rules reject ('CLI 27') would fail the request outright.
     const data: CreateProjectPayload = projectService.isEnterprise()
       ? {
           name,

--- a/src-next/cli/commands/project/views.ts
+++ b/src-next/cli/commands/project/views.ts
@@ -4,7 +4,6 @@ import type { View } from '@/cli/utils/output.ts';
 
 type Project = ProjectsGroupsModel.Project;
 
-// Java ProjectListAction formats lastActivity as an ISO date-time.
 function formatLastActivity(lastActivity: unknown): string {
   if (!lastActivity) {
     return '';
@@ -23,15 +22,13 @@ function formatLastActivity(lastActivity: unknown): string {
   return parsedDate.toISOString();
 }
 
-// Java message.project.list. ProjectListAction has no plain branch, so plain renders like text.
 export const projectView: View<Project> = {
   text: (project) => `${colors.yellow(`#${project.id}`)} ${colors.green(project.name)}`,
   keys: ['id', 'name'],
 };
 
 /**
- * The `project add` echo. Same line as the listing in text, but Java's ProjectAddAction has a plain
- * branch the listing lacks (`out.println(project.getId())`), so plain prints the bare id — the one
+ * The `project add` echo. Same line as the listing in text, but plain prints the bare id — the one
  * field a script needs from a project it just created.
  */
 export const projectAddView: View<Project> = {
@@ -40,8 +37,8 @@ export const projectAddView: View<Project> = {
   keys: projectView.keys,
 };
 
-// message.project.list.verbose adds type, visibility and last activity. Enterprise omits
-// visibility, which Java defaults to 'private'.
+// The verbose line adds type, visibility and last activity. Enterprise omits visibility, which
+// defaults to 'private'.
 export const projectVerboseView: View<Project> = {
   text: (project) =>
     `${colors.yellow(`#${project.id}`)} ${colors.green(project.name)} ${colors.green(

--- a/src-next/cli/commands/screenshot/ScreenshotCommand.ts
+++ b/src-next/cli/commands/screenshot/ScreenshotCommand.ts
@@ -48,8 +48,7 @@ interface UploadOptions extends GlobalOptions {
 
 const ALLOWED_IMAGE_EXTENSIONS = new Set(['jpeg', 'jpg', 'png', 'gif']);
 
-// Java message.screenshot.list: id, tag count, name. Shared by list and the upload/update echoes;
-// Java's plain echo prints the local file name, but the listing shape keeps the id addressable.
+// Shared by list and the upload/update echoes, so the plain echo keeps the id addressable.
 const screenshotView: View<ScreenshotView> = {
   text: (screenshot) =>
     `${colors.yellow(`#${screenshot.id}`)} ${screenshot.tagsCount} ${colors.green(screenshot.name)}`,

--- a/src-next/cli/commands/status/StatusCommand.ts
+++ b/src-next/cli/commands/status/StatusCommand.ts
@@ -165,8 +165,7 @@ export default class StatusCommand {
     }
 
     // Thrown after the progress is printed, so a failing --fail-if-incomplete run still shows which
-    // languages are behind. Java skips the check in verbose mode; here --verbose only changes the
-    // rendering, so it has no say in the exit code.
+    // languages are behind. --verbose only changes the rendering, so it has no say in the exit code.
     if (failIfIncomplete) {
       this.throwIfIncomplete(show, filteredProgressData);
     }

--- a/src-next/cli/commands/status/options.ts
+++ b/src-next/cli/commands/status/options.ts
@@ -15,10 +15,8 @@ export const directory: OptionDef = {
   description: 'Path to the directory in Crowdin',
 };
 
-// Java uses distinct descriptionKeys per mode (crowdin.status[.translation|.proofreading].*),
-// so --language and --fail-if-incomplete are worded per subcommand. Grouped so each mode's
-// wording sits together (default and translation share language wording but differ on
-// fail-if-incomplete, and can drift independently since they're separate keys).
+// --language and --fail-if-incomplete are worded per mode, so grouped per subcommand. Default and
+// translation share the language wording but differ on fail-if-incomplete.
 export const status = {
   language: {
     name: 'language',

--- a/src-next/cli/commands/status/views.ts
+++ b/src-next/cli/commands/status/views.ts
@@ -55,8 +55,7 @@ export const statusPlainView = (rows: ProgressRow[], show: ProgressView, verbose
       }
     }
 
-    // A lone section needs no header — Java prints the bare lines for `status translation`, and with
-    // one metric on screen there is nothing to tell apart.
+    // A lone section needs no header: with one metric on screen there is nothing to tell apart.
     const headed = sections.length > 1;
 
     return sections
@@ -69,7 +68,7 @@ export const statusPlainView = (rows: ProgressRow[], show: ProgressView, verbose
 });
 
 /**
- * The grid text renders: one row per language, keyed by Java's `French(fr)` header so the name and
+ * The grid text renders: one row per language, keyed by a `French(fr)` header so the name and
  * the code stay together without a column of their own. `verbose` adds the word and phrase counts
  * the verbose lines carry; the columns follow `show` either way.
  */

--- a/src-next/cli/commands/string/StringCommand.ts
+++ b/src-next/cli/commands/string/StringCommand.ts
@@ -319,8 +319,6 @@ export default class StringCommand {
       throw new CliError('Specify some parameters to edit the string');
     }
 
-    // Commander yields option values as strings, so the request builders below would forward
-    // '999' to an int field and the API would reject it.
     const [maxLength] = toNumberArray(options.maxLength, "The '--max-length' value must be numeric");
 
     if (maxLength !== undefined && maxLength < 0) {
@@ -469,7 +467,7 @@ export default class StringCommand {
   }
 
   private buildPluralText(options: AddOptions, text: string): SourceStringsModel.PluralText {
-    // The API requires the 'other' form; Java fills it from the positional text argument.
+    // The API requires the 'other' form; the positional text argument fills it.
     const plural: SourceStringsModel.PluralText = { other: text };
 
     for (const key of PLURAL_KEYS) {

--- a/src-next/cli/commands/string/options.ts
+++ b/src-next/cli/commands/string/options.ts
@@ -1,10 +1,9 @@
 import type { OptionDef } from '@/cli/types.ts';
 
-// Java uses per-subcommand descriptionKeys (crowdin.string.<sub>.<opt>), so the
-// wording differs between list/add/edit for the same flag. Grouped by subcommand
-// so each flag's per-command wording sits together and drift stays visible.
+// The wording differs between list/add/edit for the same flag, so options are grouped by
+// subcommand and each flag's per-command wording sits together.
 
-// add/edit --label share the same wording (Java `params.label`).
+// add/edit --label share the same wording.
 const labelDescription = 'Attach labels to strings (multiple labels can be specified)';
 
 export const list = {

--- a/src-next/cli/commands/string/views.ts
+++ b/src-next/cli/commands/string/views.ts
@@ -25,9 +25,9 @@ export function extractText(entry: SourceStringsModel.String): string {
 }
 
 /**
- * Java StringListAction.printSourceString: a headline plus, when verbose, indented file/labels/
- * context lines. The detail lines are the same in text and plain — only the headline differs —
- * and they need the label and file-path lookups, so the view is built per invocation.
+ * A headline plus, when verbose, indented file/labels/context lines. The detail lines are the same
+ * in text and plain — only the headline differs — and they need the label and file-path lookups,
+ * so the view is built per invocation.
  */
 export function createStringView({
   verbose = false,

--- a/src-next/cli/commands/task/views.ts
+++ b/src-next/cli/commands/task/views.ts
@@ -2,8 +2,7 @@ import type { TaskRecord } from '@/cli/services/TaskService.ts';
 import { colors } from '@/cli/utils/colors.ts';
 import type { View } from '@/cli/utils/output.ts';
 
-// Java message.task.list / message.task.list.verbose. Plain ignores the verbose flag,
-// as Java's TaskListAction does, and 'NoDueDate' stays display-only.
+// Plain ignores the verbose flag, and 'NoDueDate' stays display-only.
 export const taskView: View<TaskRecord> = {
   text: (task) => `${colors.yellow(`#${task.id}`)} ${colors.green(task.targetLanguageId ?? '')} ${task.title}`,
   plain: (task) => `${task.id} ${task.title}`,

--- a/src-next/cli/commands/tm/TmCommand.ts
+++ b/src-next/cli/commands/tm/TmCommand.ts
@@ -159,7 +159,6 @@ export default class TmCommand {
     const fileStat = await stat(fileArg).catch(() => undefined);
 
     if (fileStat === undefined) {
-      // Same wording as the Java CLI (error.file_not_found)
       throw new CliError(`File '${fileArg}' not found in the Crowdin project`);
     }
 
@@ -167,8 +166,6 @@ export default class TmCommand {
       throw new CliError('The specified file is a directory');
     }
 
-    // The Java CLI checks 'csv' and 'xslx' (a typo of 'xlsx') here; the intent
-    // per the error message is CSV or XLS/XLSX files
     if (scheme === undefined && SCHEME_EXTENSIONS.includes(extension)) {
       throw new CliError('Scheme is required for CSV or XLS/XLSX files');
     }

--- a/src-next/cli/commands/upload/UploadCommand.ts
+++ b/src-next/cli/commands/upload/UploadCommand.ts
@@ -114,7 +114,7 @@ export default class UploadCommand {
     await this.sourcesCommand.action(command);
   };
 
-  // Kept as thin aliases so existing callers/tests can drive each subcommand off UploadCommand.
+  // Thin aliases so callers/tests can drive each subcommand off UploadCommand.
   uploadSourcesAction = (command: Command) => this.sourcesCommand.action(command);
   uploadTranslationsAction = (command: Command) => this.translationsCommand.action(command);
 }

--- a/src-next/cli/commands/upload/UploadSourcesCommand.ts
+++ b/src-next/cli/commands/upload/UploadSourcesCommand.ts
@@ -127,7 +127,7 @@ export default class UploadSourcesCommand {
     }
 
     // These options have no effect on strings-based projects (the strings upload request ignores
-    // them), so warn instead of silently doing nothing. Mirrors the existing `context` warning.
+    // them), so warn instead of silently doing nothing.
     if (isStringsBasedProject) {
       if (containsExcludedLanguages) {
         output.warning("'excluded-languages' option can not be used for string-based projects");
@@ -144,8 +144,8 @@ export default class UploadSourcesCommand {
 
     this.validateExcludedTargetLanguages(patternFilePaths, project.data.targetLanguages);
 
-    // Dry-run divergence: Java delegates `--dryrun` to a separate list action; here it is handled
-    // inline and reports the concrete would-create/update/delete actions instead of just listing files.
+    // A dry run walks the same path as a real upload and reports the concrete
+    // would-create/update/delete action per file, so it looks the branch up without creating it.
     let branch: SourceFilesModel.Branch | undefined;
 
     if (options.dryrun) {
@@ -205,11 +205,10 @@ export default class UploadSourcesCommand {
       );
     }
 
-    // A machine --output emits the bare sorted in-project paths (Java DryrunSources plain view) and
-    // wins over --tree; otherwise fall through to the per-file "would be created/updated" messages.
-    // Paths are the resolved project paths, not the local ones: like Java, a dry run has to show
-    // where the file lands in Crowdin, which `dest` and a stripped common path (preserve_hierarchy:
-    // false) both move away from the repo layout.
+    // A machine --output emits the bare sorted in-project paths and wins over --tree; otherwise fall
+    // through to the per-file "would be created/updated" messages. Paths are the resolved project
+    // paths, not the local ones: a dry run has to show where the file lands in Crowdin, which `dest`
+    // and a stripped common path (preserve_hierarchy: false) both move away from the repo layout.
     if (
       options.dryrun &&
       printDryRunPaths(
@@ -233,10 +232,8 @@ export default class UploadSourcesCommand {
 
     for (const { patterns, fileOptions, files } of patternFilePaths) {
       if (files.length === 0) {
-        // Java suppresses the message under --plain and returns, so the run exits 0 on a config
-        // whose pattern matches nothing. `upload translations` keeps its exit code there and only
-        // drops the message, which is the behaviour worth carrying: a plain consumer is a script,
-        // and a script that reads success from a broken pattern uploads nothing and says nothing.
+        // plain drops the message but still fails the run: a plain consumer is a script, and a
+        // script that reads success from a broken pattern uploads nothing and says nothing.
         if (!isPlainView) {
           output.error(
             `No sources found for '${patterns.source}' pattern. Check the source paths in your configuration file`,
@@ -470,15 +467,11 @@ export default class UploadSourcesCommand {
       await saveSourceCache(config.basePath, sourceHashes, output);
     }
 
-    // Text already streamed a line per file, so only the machine formats need the summary —
-    // without it they saw an empty stdout for a command that uploaded real files. Sorted because
-    // the uploads run concurrently, and a machine contract should not depend on which finished
-    // first. Emitted before the error throw so a partial run still reports what it managed.
+    // Text already streamed a line per file, so only the machine formats need the summary. Sorted
+    // because the uploads run concurrently, and a machine contract should not depend on which
+    // finished first. Emitted before the error throw so a partial run still reports what it managed.
     //
-    // plain is line-oriented and cannot carry the action, so it lists only what changed — Java
-    // prints nothing there for a duplicate or an up-to-date file. (Java does print the empty-file
-    // skip under --plain, but that branch simply has no plainView case, like its error handler;
-    // an icon'd prose line in a stream of bare paths is the oversight, not the contract.)
+    // plain is line-oriented and cannot carry the action, so it lists only what changed.
     if (isMachineFormat(options.output)) {
       const sorted = uploadedSources.sort((one, other) => one.path.localeCompare(other.path));
 
@@ -548,7 +541,6 @@ export default class UploadSourcesCommand {
       const directoryName = directories[index] as string;
       const directoryPath = `${branch ? `/${branch.name}` : ''}/${directories.slice(0, index + 1).join('/')}`;
 
-      // Check promise cache first (set atomically before any await, safe for concurrent callers)
       if (directoryCreationPromises.has(directoryPath)) {
         directoryId = await directoryCreationPromises.get(directoryPath);
         continue;

--- a/src-next/cli/commands/upload/UploadTranslationsCommand.ts
+++ b/src-next/cli/commands/upload/UploadTranslationsCommand.ts
@@ -112,8 +112,8 @@ export default class UploadTranslationsCommand {
       serverLanguageMapping,
       output,
       options.output === 'plain',
-      // Java's dry run (ListTranslationsAction -> DryrunTranslations) resolves translation paths
-      // from local sources only; it never looks the source up in the project.
+      // A dry run resolves translation paths from local sources only; it never looks the source up
+      // in the project.
       options.dryrun ? undefined : (projectPath) => fileLookup(toProjectPath(projectPath), projectFilePaths)?.id,
     );
 
@@ -176,7 +176,7 @@ export default class UploadTranslationsCommand {
     // Text already streamed a line per file, so only the machine formats need the summary.
     // Sorted because the uploads run concurrently, and a machine contract should not depend
     // on which finished first. plain is line-oriented and cannot carry the action, so it
-    // lists only what was uploaded — Java prints nothing there for a skipped file.
+    // lists only what was uploaded.
     if (isMachineFormat(options.output)) {
       const sorted = uploadedFiles.sort((one, other) => one.path.localeCompare(other.path));
 
@@ -186,7 +186,7 @@ export default class UploadTranslationsCommand {
       );
     }
 
-    // A dry run only previews; like Java's separate list action it never fails the process.
+    // A dry run only previews, so it never fails the process.
     const failed = reportFailures(results, output);
     if (!options.dryrun && (failed || entriesHaveErrors)) {
       throw new CliError(EXECUTION_FINISHED_WITH_ERRORS);
@@ -194,11 +194,10 @@ export default class UploadTranslationsCommand {
   };
 
   /**
-   * Builds the list of translation uploads from local source files, mirroring Java's
-   * UploadTranslationsAction: sources are resolved to project paths (honoring dest /
-   * preserve_hierarchy / ignore), and each source expands to one entry per target language —
-   * or a single multi-language entry for a multilingual file (a `scheme` or `multilingual: true`)
-   * whose translation pattern has no language placeholder.
+   * Builds the list of translation uploads from local source files: sources are resolved to project
+   * paths (honoring dest / preserve_hierarchy / ignore), and each source expands to one entry per
+   * target language — or a single multi-language entry for a multilingual file (a `scheme` or
+   * `multilingual: true`) whose translation pattern has no language placeholder.
    */
   private buildTranslationEntries(
     config: Config,
@@ -219,8 +218,8 @@ export default class UploadTranslationsCommand {
         fileLanguageMapping: patterns.languages_mapping,
       });
 
-      // Java reports the empty group and moves on to the next one, keeping the message out of
-      // `--plain` so that stream stays parseable. It never flags the run as failed for this.
+      // An empty group is reported and skipped without failing the run; the message stays out of
+      // `--plain` so that stream stays parseable.
       if (localSourcePaths.length === 0) {
         if (!plainView) {
           output.error(
@@ -241,8 +240,8 @@ export default class UploadTranslationsCommand {
           fileId = resolveFileId(projectPath);
 
           if (fileId === undefined) {
-            // Java treats a source missing from the project as an error and exits non-zero, but
-            // keeps the message out of `--plain` so that stream stays parseable.
+            // A source missing from the project fails the run, but the message stays out of
+            // `--plain` so that stream stays parseable.
             if (!plainView) {
               output.error(`Source file '${localSourcePath}' does not exist in the project`);
             }
@@ -289,8 +288,8 @@ export default class UploadTranslationsCommand {
   }
 
   /**
-   * Java's DryrunTranslations passes filesMustExist=false, so a dry run lists every resolved
-   * translation path - including ones with no file on disk yet - de-duplicated.
+   * A dry run lists every resolved translation path, including ones with no file on disk yet,
+   * de-duplicated.
    */
   private dryRunPaths(entries: TranslationUploadEntry[]): string[] {
     return toSortedRelativePaths([...new Set(entries.map((entry) => entry.translationPath))]);
@@ -322,12 +321,10 @@ export default class UploadTranslationsCommand {
       options.output === 'plain',
     );
 
-    // Java DryrunTranslations plain view: bare sorted translation paths, one per line.
     if (options.dryrun && printDryRunPaths(this.dryRunPaths(entries), options, output)) {
       return;
     }
 
-    // What json/toon report at the end. Text streams per-file messages instead, so it stays empty.
     const uploadedFiles: UploadedFile[] = [];
 
     const tasks = entries.map((entry) => async () => {
@@ -365,10 +362,7 @@ export default class UploadTranslationsCommand {
 
     const results = await runConcurrently(tasks);
 
-    // Text already streamed a line per file, so only the machine formats need the summary.
-    // Sorted because the uploads run concurrently, and a machine contract should not depend
-    // on which finished first. plain is line-oriented and cannot carry the action, so it
-    // lists only what was uploaded — Java prints nothing there for a skipped file.
+    // The same machine-format summary as the file-based upload.
     if (isMachineFormat(options.output)) {
       const sorted = uploadedFiles.sort((one, other) => one.path.localeCompare(other.path));
 

--- a/src-next/cli/commands/upload/views.ts
+++ b/src-next/cli/commands/upload/views.ts
@@ -3,7 +3,7 @@ import type { View } from '@/cli/utils/output.ts';
 /**
  * What became of one uploaded file, source or translation. Text output streams its own per-file
  * messages as the upload runs; this is the summary json/toon get instead, since `output.success`
- * is text-only and those formats otherwise saw an empty stdout for a command that did real work.
+ * is text-only.
  */
 export interface UploadedFile {
   /** Project path for a source, local translation path for a translation. */
@@ -16,8 +16,6 @@ export interface UploadedFile {
 export const uploadedFileView: View<UploadedFile> = {
   // text streams its own per-file messages and never renders this list.
   text: (file) => file.path,
-  // Java's upload actions print the bare path under --plain (`out.println(fileFullPath)`) where
-  // they would otherwise print `OK.withIcon("Uploading file %s")`.
   plain: (file) => file.path,
   keys: ['path', 'action', 'reason'],
 };

--- a/src-next/cli/config.ts
+++ b/src-next/cli/config.ts
@@ -11,23 +11,22 @@ import { getIdentityFilePath, IDENTITY_FILE_NAMES } from '@/lib/identityFiles.ts
 import type { ConfigOptions, GlobalOptions } from './options.ts';
 import type { Output } from './utils/output.ts';
 
-// Default config files, matching Java's BaseCli.DEFAULT_CONFIGS. When --config is omitted, the
-// first existing one in the cwd is used; if neither exists, crowdin.yml is returned so the ensuing
-// load surfaces a not-found error naming it.
+// When --config is omitted, the first existing one in the cwd is used; if neither exists,
+// crowdin.yml is returned so the ensuing load surfaces a not-found error naming it.
 const DEFAULT_CONFIG_FILES = ['crowdin.yml', 'crowdin.yaml'] as const;
 
-// The two facts the post-merge checks need: whether the config file was read (a missing one is what
-// Java reports when there are no credentials at all) and whether any file was read (which picks the
-// error title). Kept as the raw facts so neither reading has to be guessed from the other.
+// The two facts the post-merge checks need: whether the config file was read (a missing one is the
+// error reported when there are no credentials at all) and whether any file was read (which picks
+// the error title).
 type LoadedConfig = { config: Config; fromConfigFile: boolean; fromIdentityFile: boolean };
 
 export function createGetConfig(getOutput: (command: Command) => Output) {
   let cachedLoad: LoadedConfig | undefined;
   let cachedConfigPath: string | undefined;
 
-  // Java's BaseProperties: the config file is read when present, but credentials may come entirely
-  // from flags or the environment, so a missing default file is not an error. Only the files tier
-  // (and an explicit --config) insists the file be there.
+  // The config file is read when present, but credentials may come entirely from flags or the
+  // environment, so a missing default file is not an error. Only the files tier (and an explicit
+  // --config) insists the file be there.
   const loadConfig = async (command: Command): Promise<LoadedConfig> => {
     const output = getOutput(command);
     const options = command.optsWithGlobals() as GlobalOptions & ConfigOptions;
@@ -47,16 +46,14 @@ export function createGetConfig(getOutput: (command: Command) => Output) {
     // config file, `*_env` vars, ~/.crowdin.yml token, --identity file, CLI flags — is a layer
     // here; assembleConfig folds and validates them into a ready-to-use Config.
     //
-    // Env resolution is two layers straddling the config file (Java PropertiesBuilder precedence):
-    // `*_env` outranks a literal key, CROWDIN_* underranks it. Bun auto-loads `.env` into
+    // Env resolution is two layers straddling the config file: `*_env` outranks a literal key,
+    // CROWDIN_* underranks it. Bun auto-loads `.env` into
     // process.env, so `.env` and shell vars are both covered natively.
     const config = assembleConfig(
       [envFallbackLayer(), mapConfig(raw), envKeyLayer(raw), identity ?? {}, cliLayer(options, isFilesTier(command))],
       readConfigFile || identity !== undefined,
     );
 
-    // Java resolves base_path relative to the config file's directory, expanding a leading `~`
-    // (BaseProperties.populateWithDefaultValues).
     config.basePath = resolveBasePath(config.basePath, configPath);
 
     cachedLoad = { config, fromConfigFile: readConfigFile, fromIdentityFile: identity !== undefined };
@@ -73,8 +70,8 @@ export function createGetConfig(getOutput: (command: Command) => Output) {
     return loaded.config;
   };
 
-  // Java's ProjectProperties. checkResolvedConfig already reports a missing project_id for every
-  // command that declares --project-id, so this only narrows the type for the services that read it.
+  // checkResolvedConfig already reports a missing project_id for every command that declares
+  // --project-id, so this only narrows the type for the services that read it.
   const getProjectConfig = async (command: Command): Promise<ProjectConfig> => {
     const config = await getConfig(command);
 
@@ -91,9 +88,8 @@ export function createGetConfig(getOutput: (command: Command) => Output) {
   return { getConfig, getProjectConfig, tryGetConfig };
 }
 
-// The checks Java defers until every source is merged and base_path is resolved
-// (BaseProperties/ProjectProperties.checkProperties). Java collects them into one ValidationException
-// rather than failing on the first, so a single run tells you everything that needs fixing.
+// Checks that need every source merged and base_path resolved. They are collected rather than
+// failing on the first, so a single run tells you everything that needs fixing.
 function checkResolvedConfig({ config, fromConfigFile, fromIdentityFile }: LoadedConfig, command: Command): void {
   const errors: string[] = [];
   const basePath = statSync(config.basePath, { throwIfNoEntry: false });
@@ -127,9 +123,9 @@ function checkResolvedConfig({ config, fromConfigFile, fromIdentityFile }: Loade
   throw new InvalidConfigurationError(formatConfigErrors(errors, fromConfigFile || fromIdentityFile));
 }
 
-// Mirrors Java PropertiesBuilders: the file tier reads the config file when it exists or when no
-// --source/--translation pair replaces it (ParamsWithFiles.isEmpty), other tiers only when it exists.
-// An explicit --config always must resolve, so a missing one still surfaces a not-found error.
+// The file tier reads the config file when it exists or when no --source/--translation pair replaces
+// it, other tiers only when it exists. An explicit --config must always resolve, so a missing one
+// still surfaces a not-found error.
 async function needsConfigFile(
   command: Command,
   options: GlobalOptions & ConfigOptions,
@@ -142,10 +138,9 @@ async function needsConfigFile(
   return isFilesTier(command) && !options.source && !options.translation;
 }
 
-// The command's own option set is the tier marker, the way Java's params tier is fixed by the
-// subcommand's ArgGroup: only filesConfigGroup carries --source, and only the project/files groups
-// carry --project-id (see cli/commands/common/options.ts), so this cannot drift from the tiers
-// declared there.
+// The command's own option set is the tier marker: only filesConfigGroup carries --source, and only
+// the project/files groups carry --project-id (see cli/commands/common/options.ts), so this cannot
+// drift from the tiers declared there.
 function isFilesTier(command: Command): boolean {
   return command.options.some((option) => option.attributeName() === 'source');
 }
@@ -188,10 +183,9 @@ async function resolveConfigPath(explicit: string | undefined): Promise<string> 
   return path.join(process.cwd(), DEFAULT_CONFIG_FILES[0]);
 }
 
-// Java separates "file doesn't exist" (NotFoundException, 102) from "you pointed at a folder"
-// (ValidationException, 2) for both --config and --identity (ConfigurationFilesProperties).
-// Bun.file().exists() is false for a directory, so without this an explicitly given directory
-// would exit 102 claiming the path does not exist.
+// "You pointed at a folder" (exit 2) is a different error from "file doesn't exist" (exit 102), for
+// both --config and --identity. Bun.file().exists() is false for a directory, so without this an
+// explicitly given directory would exit 102 claiming the path does not exist.
 function assertNotDirectory(filePath: string): void {
   if (statSync(filePath, { throwIfNoEntry: false })?.isDirectory()) {
     throw new InvalidConfigurationError('The specified file is a directory');
@@ -218,8 +212,7 @@ function assembleConfig(layers: Array<Record<string, unknown>>, fromAnyFile: boo
 
   const parsed = ConfigSchema.safeParse(merged);
 
-  // Java throws ValidationException (exit 2) for an invalid config; surface zod errors as the same,
-  // under the same title and bullet list the post-merge checks use.
+  // Same title and bullet list as the post-merge checks.
   if (!parsed.success) {
     throw new InvalidConfigurationError(
       formatConfigErrors(
@@ -269,9 +262,9 @@ function credentialLayer(raw: Record<string, unknown>): Record<string, unknown> 
   };
 }
 
-// Identity credentials, matching Java's identity-file handling. The file is `--identity` when given,
-// otherwise the first existing default (~/.crowdin.yml, then ~/.crowdin.yaml). It contributes all
-// four credential fields (with `*_env` resolution), overriding the config file but not CLI flags.
+// Identity credentials. The file is `--identity` when given, otherwise the first existing default
+// (~/.crowdin.yml, then ~/.crowdin.yaml). It contributes all four credential fields (with `*_env`
+// resolution), overriding the config file but not CLI flags.
 // A `--identity` file that does not exist is an error; missing default files are simply skipped.
 // Returns undefined when no identity file was read, which (with the config file) decides whether an
 // invalid config is reported as "Configuration file is invalid" or "Configuration is invalid".
@@ -282,8 +275,6 @@ async function identityLayer(
   let identityPath = options.identity;
 
   if (identityPath) {
-    // Java tests `configFile.isDirectory()` here, which is a slip in its own source; check the
-    // identity file the option actually named.
     assertNotDirectory(identityPath);
 
     if (!(await Bun.file(identityPath).exists())) {
@@ -299,7 +290,7 @@ async function identityLayer(
 
   output.debug(`Loading credentials from '${identityPath}' file`);
 
-  // Java tolerates an empty identity file (unlike an empty config file), so parse leniently.
+  // An empty identity file is tolerated (unlike an empty config file), so parse leniently.
   const parsed = loadYaml(await Bun.file(identityPath).text());
 
   return parsed && typeof parsed === 'object' ? credentialLayer(parsed as Record<string, unknown>) : {};
@@ -317,8 +308,8 @@ async function firstExistingDefaultIdentityFile(): Promise<string | undefined> {
   return undefined;
 }
 
-// CLI flag overrides. Mirrors Java's PropertiesWithFilesBuilder: --source/--translation build a
-// single-file override, and --dest folds into that same file (also forcing preserve_hierarchy on).
+// CLI flag overrides. On the files tier --source/--translation build a single-file override, and
+// --dest folds into that same file (also forcing preserve_hierarchy on).
 function cliLayer(options: GlobalOptions & ConfigOptions, filesTier: boolean): Partial<Config> {
   const layer: Partial<Config> = {
     apiToken: options.token,
@@ -328,7 +319,6 @@ function cliLayer(options: GlobalOptions & ConfigOptions, filesTier: boolean): P
     preserveHierarchy: options.preserveHierarchy,
   };
 
-  // Only file-tier commands turn --source/--translation into a single-file override.
   if (!filesTier) {
     return layer;
   }
@@ -346,8 +336,8 @@ function cliLayer(options: GlobalOptions & ConfigOptions, filesTier: boolean): P
       layer.preserveHierarchy = true;
     }
   } else {
-    // Mirrors Java PropertiesWithFilesBuilder: --source/--translation must come as a pair, and --dest
-    // is meaningless without both. Accumulate like Java's messages.addError so both surface at once.
+    // --source/--translation must come as a pair, and --dest is meaningless without both. Both errors
+    // are collected so they surface at once.
     const errors: string[] = [];
 
     if (Boolean(options.source) !== Boolean(options.translation)) {

--- a/src-next/cli/errors/WrongLanguageError.ts
+++ b/src-next/cli/errors/WrongLanguageError.ts
@@ -2,7 +2,7 @@ import { CrowdinError } from '@crowdin/crowdin-api-client';
 import CliError from './CliError.ts';
 
 // The API rejects an import when the storage file's detected language does not match the
-// requested target language. Java's CrowdinProjectClient matches this on the message prefix.
+// requested target language, recognisable only by the message prefix.
 const WRONG_LANGUAGE_MESSAGE_PREFIX = 'File is not allowed for the';
 
 export default class WrongLanguageError extends CliError {

--- a/src-next/cli/errors/toCliError.ts
+++ b/src-next/cli/errors/toCliError.ts
@@ -6,8 +6,7 @@ import NotFoundError from './NotFoundError.ts';
 import RateLimitError from './RateLimitError.ts';
 
 // A connection failure arrives as a wrapped CrowdinError (code 500) whose message is the raw
-// error from the HTTP layer. Java matched "Name or service not known"; Bun/axios surface these
-// tokens instead. Two buckets, because they mean different things to the user:
+// error from the HTTP layer. Two buckets, because they mean different things to the user:
 //
 //   ENOTFOUND  - DNS answered "no such host": the URL itself is wrong.
 //   everything else - the name resolved (or the resolver was unreachable) and the socket failed:
@@ -41,14 +40,11 @@ function connectionMessage(message: string): string | undefined {
   return undefined;
 }
 
-// Mirrors Java's CrowdinClientCore.standardErrorHandlers: maps the HTTP status of an
-// API error onto the matching exit code. The Java substring branches (Project/Bundle Not
-// Found, "upgrade subscription", ...) all collapse to the same code as their generic status
-// sibling, so a pure status switch reproduces every exit code.
+// Maps the HTTP status of an API error onto the matching exit code.
 //
-// Hybrid message strategy: 401 and invalid-url get Java's curated text (they're unambiguous —
-// a 401 always means a bad token, an ECONNREFUSED always points at base_url). 403/404/429 stay
-// contextual, because a fixed "project doesn't exist" would mislabel a file/branch/bundle 404.
+// 401 and an unknown host get curated text (they're unambiguous — a 401 always means a bad token,
+// an unknown host always points at base_url). 403/404/429 stay contextual, because a fixed
+// "project doesn't exist" would mislabel a file/branch/bundle 404.
 export function mapCrowdinError(error: CrowdinError, fallbackMessage: string): CliError {
   if (error.code === 401) {
     return new AuthorizationError("Couldn't authorize. Check your 'api_token'");

--- a/src-next/cli/services.ts
+++ b/src-next/cli/services.ts
@@ -63,9 +63,9 @@ export function createGetApiClient(getConfig: GetConfig) {
       throw new ValidationError("Required option 'api_token' is missing");
     }
 
-    // Proxy parity with the Java CLI: HTTP_PROXY_HOST/PORT/USER/PASSWORD env vars.
-    // Bun's fetch honors HTTPS_PROXY/HTTP_PROXY (incl. credentials in the URL), so we
-    // translate the custom vars into the standard ones and force the fetch HTTP client.
+    // Bun's fetch honors HTTPS_PROXY/HTTP_PROXY (incl. credentials in the URL), so the custom
+    // HTTP_PROXY_HOST/PORT/USER/PASSWORD vars are translated into the standard ones and the fetch
+    // HTTP client is forced.
     const proxy = proxyUrlFromEnv();
 
     if (proxy) {

--- a/src-next/cli/services/BranchService.ts
+++ b/src-next/cli/services/BranchService.ts
@@ -5,7 +5,7 @@ import CliError from '../errors/CliError.ts';
 import { toCliError } from '../errors/toCliError.ts';
 import { normalizeBranchName } from '../utils/parsing.ts';
 
-// Reports each poll's percentage so the command can render its own progress (Java updates a spinner).
+// Reports each poll's percentage so the command can render its own progress.
 export type ProgressCallback = (progress: number) => void;
 
 export class BranchService {

--- a/src-next/cli/services/BundleService.ts
+++ b/src-next/cli/services/BundleService.ts
@@ -9,8 +9,8 @@ export type BundleView = BundlesModel.Bundle & {
 
 export type AddBundlePayload = BundlesModel.CreateBundleRequest;
 
-// Mirrors Java's executeRequestWithPossibleRetries: retry the export start on a transient
-// "another export in progress" / server / network error before giving up.
+// Retry the export start on a transient "another export in progress" / server / network error
+// before giving up.
 const EXPORT_RETRY_ATTEMPTS = 3;
 const EXPORT_RETRY_DELAY_MS = 3000;
 

--- a/src-next/cli/services/DistributionService.ts
+++ b/src-next/cli/services/DistributionService.ts
@@ -9,7 +9,7 @@ interface ReleaseStatus {
   progress?: number | null;
 }
 
-// The release poll stops on any of these; only "failed" is an error (Java treats success/finished alike).
+// The release poll stops on any of these; only "failed" is an error.
 const RELEASE_TERMINAL_STATUSES = new Set(['success', 'finished', 'failed']);
 
 export class DistributionService {
@@ -20,8 +20,7 @@ export class DistributionService {
 
   async list(): Promise<DistributionView[]> {
     try {
-      // Java threads limit/offset through executeRequestFullList here, so it returns every
-      // distribution; without withFetchAll this stops at the API's default page size.
+      // Without withFetchAll this stops at the API's default page size.
       const response = await this.client.distributionsApi.withFetchAll().listDistributions(this.projectId);
 
       return response.data.map((entry) => entry.data);

--- a/src-next/cli/services/FileService.ts
+++ b/src-next/cli/services/FileService.ts
@@ -111,8 +111,7 @@ export class FileService {
   // Scoped to one branch, and to the root tree when none is given: without a branchId the endpoint
   // returns every branch's files too, whose paths carry the branch name, so they would answer to
   // their prefixed path everywhere below (and 'upload sources --delete-obsolete' would delete them
-  // as obsolete). Java scopes the same way, by equality that treats null as the root
-  // (CrowdinProjectFull.getFiles(branchId)).
+  // as obsolete).
   async loadProjectFiles(branchId?: number) {
     const response = await withSpinner(
       this.output,
@@ -128,14 +127,8 @@ export class FileService {
   }
 
   // A file inside a branch is addressable only once '--branch' names that branch: the branch is
-  // never part of '--file', and without one every path would silently resolve against whichever
-  // branch happened to be listed first.
-  //
-  // This is a deliberate deviation, not parity: Java (StringAddAction) keeps branch files in the
-  // lookup even with no branch given and builds their keys off the directory tree alone
-  // (ProjectFilesUtils.buildFilePaths without branches), so two branches holding the same relative
-  // path collide and the last one into the HashMap wins. Dropping them is the whole point here —
-  // don't "restore parity" by deleting the filter.
+  // never part of '--file', so without the filter two branches holding the same relative path would
+  // collide and one would silently win.
   private async loadFileIdsByPath(branch?: ProjectBranch): Promise<Map<string, number>> {
     const files = await this.fetchProjectFiles(branch?.id);
     const addressable = branch ? files : files.filter((file) => file.branchId === null);
@@ -182,14 +175,12 @@ export class FileService {
     }
   }
 
-  // Server paths carry the branch name, the path given on the command line never does, so '--file'
-  // stays branch-relative and the branch only arrives through '--branch'. Branch-relative keys do
-  // match Java, which builds them off the directory tree alone; what differs is which files reach
-  // the lookup at all (see loadFileIdsByPath).
   private firstPathSegment(projectPath: string): string | undefined {
     return normalizePath(projectPath).split('/')[1];
   }
 
+  // Server paths carry the branch name, the path given on the command line never does, so '--file'
+  // stays branch-relative and the branch only arrives through '--branch'.
   private toLookupPath(projectPath: string, branchName?: string): string {
     return stripBranchPrefix(normalizePath(projectPath), branchName);
   }

--- a/src-next/cli/services/GlossaryService.ts
+++ b/src-next/cli/services/GlossaryService.ts
@@ -37,8 +37,8 @@ export class GlossaryService {
     }
   }
 
-  // Unlike the Java CLI, the term list is capped: glossaries can hold millions
-  // of terms and fetching them all just for the verbose listing hangs the CLI
+  // Capped: glossaries can hold millions of terms, and fetching them all just for the verbose
+  // listing hangs the CLI.
   async listTerms(glossaryId: number, maxTerms = 500): Promise<GlossariesModel.Term[]> {
     try {
       const response = await this.apiClient.glossariesApi.withFetchAll(maxTerms).listTerms(glossaryId);

--- a/src-next/cli/services/ProjectService.ts
+++ b/src-next/cli/services/ProjectService.ts
@@ -5,7 +5,7 @@ import { withSpinner } from '../utils/withSpinner.ts';
 
 /**
  * What `project add` sends. `identifier` is omitted deliberately — the API derives it from the
- * name, and the CLI never had a value that could satisfy its character rules.
+ * name.
  */
 export type CreateProjectPayload =
   | ProjectsGroupsModel.CreateProjectEnterpriseRequest
@@ -24,9 +24,7 @@ export class ProjectService {
 
   async addProject(data: CreateProjectPayload) {
     try {
-      // The cast covers the omitted `identifier`, which the client types as required: the API
-      // derives it from the name when it is absent, which is what Java's RequestBuilder.addProject
-      // relies on — it never sends one.
+      // The cast covers the omitted `identifier`, which the client types as required.
       return await this.apiClient.projectsGroupsApi.addProject(data as ProjectsGroupsModel.CreateProjectRequest);
     } catch (error) {
       throw toCliError(error, 'Failed to add project');

--- a/src-next/cli/services/TranslationService.ts
+++ b/src-next/cli/services/TranslationService.ts
@@ -5,8 +5,8 @@ import WrongLanguageError from '../errors/WrongLanguageError.ts';
 import type { Output } from '../utils/output.ts';
 import { withSpinner } from '../utils/withSpinner.ts';
 
-// Reported once per poll, so each command can word its own progress line (Java words them
-// differently per command: verbose-only for `upload translations`, always for `file upload`).
+// Reported once per poll, so each command can word its own progress line (verbose-only for
+// `upload translations`, always for `file upload`).
 export type ImportProgress = (
   status: Status<
     TranslationsModel.ImportTranslationsStatusAttributes | TranslationsModel.ImportTranslationsStringsStatusAttributes
@@ -64,8 +64,8 @@ export class TranslationService {
   }
 
   // The import is queued server-side, so the request alone proves nothing: wait for the status to
-  // finish before returning, the way Java's executeAsyncAction does. Keeping the wait here means a
-  // caller cannot mistake "queued" for "done" — the bug that shipped when commands had to remember.
+  // finish before returning. Keeping the wait here means a caller cannot mistake "queued" for
+  // "done".
   private async importAndWait(
     request: TranslationsModel.ImportTranslationsRequest | TranslationsModel.ImportTranslationsStringsRequest,
     filePath: string,

--- a/src-next/cli/utils/aiContext.ts
+++ b/src-next/cli/utils/aiContext.ts
@@ -6,7 +6,7 @@ const AI_CONTEXT_MARKER_END = '✨ 🔚';
 const AI_CONTEXT_SECTION_START = `\n\n${AI_CONTEXT_MARKER_START}\n`;
 const AI_CONTEXT_SECTION_END = `\n${AI_CONTEXT_MARKER_END}`;
 
-// Mirrors the jsonl record produced by the Java CLI ('crowdin context download')
+// One line of the JSONL file 'crowdin context download' writes.
 export interface StringContextRecord {
   id: number;
   key: string;
@@ -96,9 +96,8 @@ export async function readContextFile(filePath: string): Promise<ContextFileCont
   return { records, ...(firstInvalidLine !== undefined ? { firstInvalidLine } : {}) };
 }
 
-// A malformed or incomplete line yields no record. Unlike the Java CLI, which drops such lines
-// silently, the callers refuse the file: both of them rewrite what they read, so a dropped line is
-// context about to be lost.
+// A malformed or incomplete line yields no record, and the callers refuse the file: both of them
+// rewrite what they read, so a dropped line is context about to be lost.
 function parseContextRecord(line: string): StringContextRecord | null {
   try {
     const parsed: unknown = JSON.parse(line);
@@ -133,7 +132,7 @@ function parseContextRecord(line: string): StringContextRecord | null {
   }
 }
 
-// Plural texts are flattened to 'form: value | form: value', same as the Java CLI
+// Plural texts are flattened to 'form: value | form: value'.
 export function getStringText(text: string | SourceStringsModel.PluralText | undefined): string {
   if (typeof text === 'string') {
     return text;

--- a/src-next/cli/utils/argFiles.ts
+++ b/src-next/cli/utils/argFiles.ts
@@ -1,9 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-// Mirrors picocli's @-file expansion (PicocliRunner sets setExpandAtFiles(true),
-// and does NOT enable simplified mode, so this reproduces picocli's *default*
-// argument-file format):
+// @-file expansion: an `@path` argument is replaced by the arguments read from that file.
 //
 //   - arguments are whitespace-separated (spaces, tabs, newlines)
 //   - single or double quotes group an argument and are stripped
@@ -13,13 +11,12 @@ import { resolve } from 'node:path';
 //
 //   crowdin @args.txt   ->   args from args.txt spliced in place
 //   @@foo               ->   literal "@foo" (escape, no file read)
-//   missing file        ->   "@path" kept literal (picocli does not error)
+//   missing file        ->   "@path" kept literal (no error)
 //
 // A file arg starting with "@" inside the file is expanded recursively; a cycle
 // guard keeps that from looping forever.
 //
-// ponytail: does not emulate StreamTokenizer's octal/unicode escape quirks or the
-// broken `opt="v"` (equals-before-quote) case; add only if a real arg file needs it.
+// ponytail: no octal/unicode escapes; add only if a real arg file needs them.
 const COMMENT_CHAR = '#';
 
 export function expandArgFiles(args: string[]): string[] {
@@ -31,7 +28,6 @@ function expand(args: string[], seen: Set<string>): string[] {
 
   for (const arg of args) {
     if (arg.startsWith('@@')) {
-      // Escaped: drop one '@', no expansion.
       result.push(arg.slice(1));
       continue;
     }
@@ -44,7 +40,7 @@ function expand(args: string[], seen: Set<string>): string[] {
     const path = resolve(arg.slice(1));
 
     if (seen.has(path) || !existsSync(path)) {
-      // Cycle or unreadable file: keep the @-arg literal, like picocli.
+      // Cycle or unreadable file: keep the @-arg literal.
       result.push(arg);
       continue;
     }
@@ -63,8 +59,6 @@ function readArgFile(path: string): string[] {
   return tokenize(readFileSync(path, 'utf8'));
 }
 
-// Picocli default-mode tokenizer: whitespace splits, quotes group, backslash
-// escapes inside quotes, unquoted COMMENT_CHAR runs to end of line.
 function tokenize(content: string): string[] {
   const tokens: string[] = [];
   let cur = '';

--- a/src-next/cli/utils/checkVersion.ts
+++ b/src-next/cli/utils/checkVersion.ts
@@ -5,9 +5,7 @@ import type { Output } from './output.ts';
 
 const VERSION_FILE_URL = 'https://github.com/crowdin/crowdin-cli/releases/latest/download/version.txt';
 const TIMEOUT_MS = 3000;
-// Only hit the network once per day; between checks the banner is served from the cached latest version
-// so it still shows on every command without a request per invocation.
-const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hr
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 interface VersionCache {
   lastCheck: number;
@@ -31,9 +29,6 @@ interface CheckOptions {
  * last-seen version is read from a small cache file, so the banner still appears every command without a
  * network request each time. Any failure (offline, timeout, bad response, unreadable cache) is swallowed
  * so it never affects the command; a stale cache is used as a fallback when the network is unreachable.
- *
- * NOTE: differs from the Java CheckNewVersionAction, which fetched on every run and used plain string
- * inequality (`!version.equals(latest)`), showing the banner on any mismatch including downgrades.
  */
 export async function checkNewVersion(output: Output, currentVersion: string, opts: CheckOptions = {}): Promise<void> {
   const cachePath = opts.cachePath ?? defaultCachePath();

--- a/src-next/cli/utils/downloadToFile.ts
+++ b/src-next/cli/utils/downloadToFile.ts
@@ -9,9 +9,9 @@ import CliError from '@/cli/errors/CliError.ts';
  * Streams a download to a local file, creating the parent directory.
  *
  * Not `Bun.write(path, response)`: on Bun 1.4.0 that call never settles when the GC collects the
- * Response while the body is still arriving (oven-sh/bun#40278), so the CLI stops with no file, no
- * error and no exit. Piping the body through node's stream pipeline is the same single streaming
- * pass without the stall.
+ * Response while the body is still arriving, so the CLI stops with no file, no error and no exit.
+ * Piping the body through node's stream pipeline is the same single streaming pass without the
+ * stall.
  *
  * Two spellings that look tidier are silently wrong on the same version: `Bun.write(path,
  * response.body)` stringifies the stream and writes 23 bytes of "[object ReadableStream]", and

--- a/src-next/cli/utils/fileTree.ts
+++ b/src-next/cli/utils/fileTree.ts
@@ -2,7 +2,7 @@ import { toPosixPath } from '@/lib/utils/path.ts';
 import { colors } from './colors.ts';
 import type { Output } from './output.ts';
 
-// Java message.tree.*: the glyphs are cyan, the names they prefix are not. Colored at render time
+// The glyphs are cyan, the names they prefix are not. Colored at render time
 // rather than here, since colors are only switched on once the output format is known.
 const ELEM = '├─ ';
 const LAST_ELEM = '╰─ ';

--- a/src-next/cli/utils/output.ts
+++ b/src-next/cli/utils/output.ts
@@ -48,21 +48,20 @@ export type OutputOptions = {
   withGuide?: boolean;
 };
 
-/**
- * How one entity renders per `--output` format: a line in text and plain, a narrowed record in
- * json/toon.
- */
 /** A row-list grid: column definitions plus the rows themselves, duplicates and all. */
 export type TableGrid = {
   columns: { name: string; title: string; alignment?: 'left' | 'right' }[];
   rows: Record<string, string | number>[];
 };
 
+/**
+ * How one entity renders per `--output` format: a line in text and plain, a narrowed record in
+ * json/toon.
+ */
 export type View<T> = {
-  /** The default line, mirroring the Java message templates (`message.branch.list` and friends). */
   text: (item: T) => string;
   /**
-   * Java's plain line, when it differs from `text` (e.g. branch prints the name alone); left off,
+   * The plain line, when it differs from `text` (e.g. branch prints the name alone); left off,
    * plain prints `text`. What belongs on it — and why its wording is frozen once shipped — is the
    * render-command-output skill (.agents/skills/render-command-output/SKILL.md).
    */
@@ -94,7 +93,6 @@ export function createOutput(options: GlobalOptions, { withGuide = false }: Outp
   enableColors(options.colors && format === 'text');
 
   updateSettings({
-    // Guide lines off by default; interactive commands (init) opt back in
     withGuide,
   });
 
@@ -107,16 +105,12 @@ export function createOutput(options: GlobalOptions, { withGuide = false }: Outp
   /**
    * Diagnostics go to stderr in every format, so stdout only ever carries the result document —
    * a command that warns about three files and then fails still leaves parseable output behind.
-   *
-   * They used to print to stdout, and warnings were dropped outside text entirely, so `--output`
-   * consumers silently lost every 'project doesn't contain the file' notice.
    */
   function diagnostic(level: 'error' | 'warning', message: string, code?: number): void {
-    // One record per diagnostic, not one document per run: they are emitted as they happen, so
-    // buffering to exit would lose every warning a killed upload had already produced. json
-    // separates records by newline, toon by blank line; both escape newlines inside a message,
-    // so neither separator can appear within a record. TOON's list form would give one document
-    // but declares its record count up front ('[2]{level,message}:'), unknowable mid-run.
+    // One record per diagnostic, emitted as it happens, so a killed run keeps the warnings it
+    // already produced. json separates records by newline, toon by blank line; both escape newlines
+    // inside a message, so neither separator can appear within a record. TOON's list form is out:
+    // it declares its record count up front ('[2]{level,message}:'), unknowable mid-run.
     if (isStructured) {
       const record = { level, message, ...(code !== undefined ? { code } : {}) };
 
@@ -126,9 +120,7 @@ export function createOutput(options: GlobalOptions, { withGuide = false }: Outp
       return;
     }
 
-    // plain drops the symbol for the same reason its views do: the line is the contract. This
-    // one departs from Java, whose top-level handler prints ERROR.withIcon() to stderr without
-    // ever seeing the plainView flag, so '--plain' there still carries the icon.
+    // plain drops the symbol for the same reason its views do: the line is the contract.
     if (format === 'plain') {
       console.error(message);
       return;
@@ -167,9 +159,8 @@ export function createOutput(options: GlobalOptions, { withGuide = false }: Outp
           columns,
           shouldDisableColors: !options.colors,
           // The library paints every cell white, which reads as grey next to the rest of the output.
-          // An unmapped colour renders as plain text, so dropping 'white' leaves cells in the
-          // terminal's own foreground with only the header bold — what Bun.inspect.table does in
-          // table() above.
+          // An unmapped colour renders as plain text, leaving cells in the terminal's own foreground
+          // with only the header bold, as table() does.
           colorMap: { white: undefined },
         });
 
@@ -189,8 +180,7 @@ export function createOutput(options: GlobalOptions, { withGuide = false }: Outp
      */
     table(data: object | unknown[]): void {
       if (format === 'text') {
-        // console.table bolds its header row on a TTY with no way to opt out, so --no-colors
-        // leaked styling through it. Bun.inspect.table renders the same grid and takes the flag.
+        // Not console.table: it bolds the header row on a TTY and ignores --no-colors.
         // trimEnd because the rendered grid ends in a newline and console.log adds its own.
         console.log(Bun.inspect.table(data, { colors: options.colors }).trimEnd());
         return;
@@ -296,8 +286,8 @@ export function createOutput(options: GlobalOptions, { withGuide = false }: Outp
       message: string,
     ): void {
       if (format !== 'text' || !options.progress) {
-        // Reporting here produced a record with no `code` and, since `withSpinner` marks the error
-        // `reported`, suppressed the handler's record that would have carried one.
+        // Structured formats leave the error to the top-level handler, whose record carries the
+        // exit code.
         if (operation === 'error') {
           if (!isStructured) {
             this.error(message);
@@ -376,7 +366,7 @@ export function getOutputFormatFromArgs(argv: string[]): GlobalOptions {
     verbose: false,
     output: outputFormat,
     // Scanned from argv (not parsed opts) because the top-level error handler runs outside any
-    // command action, where parsing may have thrown. Mirrors Java's originalArgs().contains("--debug").
+    // command action, where parsing may have thrown.
     debug: argv.includes('--debug'),
   };
 }

--- a/src-next/cli/utils/parsing.ts
+++ b/src-next/cli/utils/parsing.ts
@@ -1,10 +1,9 @@
 import ValidationError from '@/cli/errors/ValidationError.ts';
 import { stripLeadingSlashes, stripTrailingSlashes, toPosixPath } from '@/lib/utils/path.ts';
 
-// Java declares these ids as `Long`, so picocli converts them with Long.parseLong and reports a
-// usage error (exit 2) for anything else. `Number()` is far looser — it accepts '1.5', '1e3',
-// '0x10', ' 12 ' and 'Infinity', and turns '  ' into 0 — which would forward junk to the API as a
-// real id, so match Long.parseLong's grammar instead.
+// Anything but an optionally signed run of digits is a usage error (exit 2). `Number()` alone is far
+// looser — it accepts '1.5', '1e3', '0x10', ' 12 ' and 'Infinity', and turns '  ' into 0 — which
+// would forward junk to the API as a real id.
 export function parseNumericId(value: string | undefined, entityName: string): number {
   if (!value) {
     throw new ValidationError(`${entityName} id can not be empty`);
@@ -35,7 +34,7 @@ export function toNumberArray(value: NumericInput, errorMessage: string): number
   const values = Array.isArray(value) ? value : [value];
 
   return values.map((entry) => {
-    // Java parses these as List<Long>, so hold string input to the same grammar as parseNumericId.
+    // String input is held to the same grammar as parseNumericId.
     if (typeof entry === 'number') {
       return entry;
     }
@@ -73,8 +72,7 @@ export function parseScheme(values: string[]): Record<string, number> | undefine
     // `!column`, not `column === undefined`: `Number('')` is 0, so 'en=' would otherwise clear the
     // integer guard and silently mean column 0 — the first real column.
     if (!key || !column || rest.length > 0 || !Number.isInteger(index) || index < 0) {
-      // Java takes --scheme as Map<String, Integer>, so picocli rejects a malformed value as a
-      // usage error (exit 2) rather than a generic failure.
+      // A usage error (exit 2) rather than a generic failure.
       throw new ValidationError(
         `The '--scheme' parameter has an invalid value '${value}'. Expected format: <column>=<index> (e.g. en=0)`,
       );

--- a/src-next/cli/utils/pathMatcher.ts
+++ b/src-next/cli/utils/pathMatcher.ts
@@ -4,11 +4,9 @@ import { toPosixPath } from '@/lib/utils/path.ts';
  * Matches a project file path against a **user-supplied CLI filter** (`--file`, `--filter`), not
  * against a config `source`/`ignore` pattern. Config patterns go through
  * `lib/config/projectFileMatch.ts::matchesSourcePattern`, which additionally expands the file
- * placeholders and applies the `preserve_hierarchy` tiers the way Java's
- * `formatSourcePatternForRegex` does. Using this one on a config pattern silently drops both —
- * `obsoleteEntries` did, and a `source` carrying `%original_file_name%` matched nothing.
+ * placeholders and applies the `preserve_hierarchy` tiers. Using this one on a config pattern
+ * silently drops both.
  *
- * Mirrors the Java CLI FileHelper.isPathMatch semantics:
  * - '**' matches any number of directories
  * - '*' matches one or more characters within a path segment
  * - '?' matches a single character within a path segment

--- a/src-next/cli/utils/proxy.ts
+++ b/src-next/cli/utils/proxy.ts
@@ -1,5 +1,5 @@
-// Mirrors the Java CLI's custom proxy env vars (BaseCli.HTTP_PROXY_*).
-// Both host and port are required; port must be numeric (Java parity).
+// Proxy from the HTTP_PROXY_HOST/PORT/USER/PASSWORD env vars.
+// Both host and port are required; port must be numeric.
 // Credentials are optional and only applied when both user and password are set.
 export function proxyUrlFromEnv(): string | undefined {
   const host = process.env.HTTP_PROXY_HOST;

--- a/src-next/cli/utils/withSpinner.ts
+++ b/src-next/cli/utils/withSpinner.ts
@@ -11,12 +11,11 @@ export interface SpinnerMessages<T> {
 }
 
 /**
- * Runs an operation behind a spinner, mirroring Java's ConsoleSpinner.execute.
+ * Runs an operation behind a spinner.
  *
  * On failure the spinner line carries the *full* `CliError` message — the `fail` prefix plus
  * whatever the API said — and the error is marked `reported`, so `cli.ts` does not print it a
- * second time. Services used to split between this and showing a short fixed line while leaving
- * `reported` unset, which made half of them print the failure twice.
+ * second time.
  */
 export async function withSpinner<T>(
   output: Output,

--- a/src-next/lib/api/pollStatus.ts
+++ b/src-next/lib/api/pollStatus.ts
@@ -18,16 +18,15 @@ export async function pollUntilFinished<T extends PollableStatus>(
   poll: (current: T) => Promise<ResponseObject<T>>,
   // A function when the message depends on the failure itself (a build carries `error.message`).
   failureMessage: string | ((current: T) => string),
-  // Called with each polled status so callers can report progress the way Java's
-  // executeAsyncActionWithoutSpinner does. Not called for a failed status, which raises instead.
+  // Called with each polled status so callers can report progress. Not called for a failed status,
+  // which raises instead.
   onProgress?: (status: T) => void,
 ): Promise<ResponseObject<T>> {
   let current = initial;
 
   // Case-insensitive: some endpoints return "finished"/"failed", others capitalize (e.g. bundle export).
   // `canceled` is terminal too (BuildStatus is created|inProgress|canceled|failed|finished), so it
-  // has to end the loop — waiting for a cancelled job to reach "finished" never returns. Java shares
-  // this gap and hangs; ending the wait is a deliberate divergence.
+  // has to end the loop — waiting for a cancelled job to reach "finished" never returns.
   const isFailure = (status: string) => status === 'failed' || status === 'canceled';
 
   while (current.data.status.toLowerCase() !== 'finished') {

--- a/src-next/lib/common/errors/FileNotFoundError.ts
+++ b/src-next/lib/common/errors/FileNotFoundError.ts
@@ -1,7 +1,6 @@
 export default class FileNotFoundError extends Error {
-  // Java maps a missing config/identity/archive file to NotFoundException (exit 102).
-  // Hardcoded rather than imported from cli/errors ExitCode to keep lib/ free of a cli/
-  // dependency; cli.ts getExitCode duck-types this `exitCode` property.
+  // Exit 102, the not-found code. Hardcoded rather than imported from cli/errors ExitCode to keep
+  // lib/ free of a cli/ dependency; cli.ts getExitCode duck-types this `exitCode` property.
   readonly exitCode = 102;
 
   constructor(message: string = 'File Not Found', options?: ErrorOptions) {

--- a/src-next/lib/config.ts
+++ b/src-next/lib/config.ts
@@ -4,7 +4,7 @@ import { containsPattern } from './config/projectFileMatch.ts';
 import { filePatterns, languagePatterns } from './export/patterns.ts';
 import { collapseSeparators, stripLeadingSlashes } from './utils/path.ts';
 
-// Accepted base_url hosts, ported from Java PropertiesBeanUtils.isUrlOfficial / isUrlForTesting.
+// Accepted base_url hosts.
 const BASE_URL_PATTERNS = [
   /^https:\/\/[^.]+\.(api\.)?crowdin\.com$/, // <org>.crowdin.com, <org>.api.crowdin.com (enterprise)
   /^https:\/\/(api\.)?crowdin\.com$/, // crowdin.com, api.crowdin.com (official)
@@ -14,19 +14,18 @@ const BASE_URL_PATTERNS = [
   /^https:\/\/.+\.e-test\.crowdin\.com$/,
 ];
 
-// Documented config `update_option` values → API enum (Java PropertiesBeanUtils.getUpdateOption).
+// Documented config `update_option` values → API enum.
 const UPDATE_OPTION_MAP = {
   update_as_unapproved: 'keep_translations',
   update_without_changes: 'keep_translations_and_approvals',
 } as const;
 
-// Strips a trailing /api, /api/v2, or slash (Java BaseProperties normalizes with removePattern).
+// Strips a trailing /api, /api/v2, or slash.
 function normalizeBaseUrl(url: string): string {
   return url.replace(/\/(api(\/|\/v2\/?)?)?$/, '');
 }
 
-// Java coerces booleans via setBooleanPropertyIfExists ("1" -> true, else Boolean.valueOf),
-// so accept 0/1 and their string forms in addition to real booleans.
+// Accepts 0/1 and their string forms in addition to real booleans.
 const coercedBoolean = z.preprocess((value) => {
   if (value === 1 || value === '1' || value === true || value === 'true') {
     return true;
@@ -40,8 +39,8 @@ const coercedBoolean = z.preprocess((value) => {
 }, z.boolean());
 
 /**
- * A file is multilingual via a `scheme` or an explicit `multilingual: true`, the rule Java's
- * FileBean applies when it decides a language placeholder is not required.
+ * A file is multilingual via a `scheme` or an explicit `multilingual: true`; its `translation` then
+ * needs no language placeholder.
  */
 export function isMultilingualFile(file: { scheme?: unknown; multilingual?: boolean }): boolean {
   return file.scheme !== undefined || file.multilingual === true;
@@ -49,9 +48,9 @@ export function isMultilingualFile(file: { scheme?: unknown; multilingual?: bool
 
 export const ConfigSchema = z
   .object({
-    // Optional here because the base tier (glossary, tm) talks to the API without a project context,
-    // exactly like Java's BaseProperties. Project-scoped commands restore the requirement via
-    // assertProjectConfigured; cli/config.ts maps commands to tiers.
+    // Optional here because the base tier (glossary, tm) talks to the API without a project context.
+    // Project-scoped commands restore the requirement via assertProjectConfigured; cli/config.ts maps
+    // commands to tiers.
     projectId: z.preprocess(
       (value) => (typeof value === 'string' && value.trim() === '' ? undefined : value),
       z.coerce
@@ -59,9 +58,8 @@ export const ConfigSchema = z
         .gt(0, "Option 'project_id' must be a numeric value")
         .optional(),
     ),
-    // Java only rejects an empty token (BaseProperties: isEmpty → missed_api_token); token length/
-    // validity is the API's job (401), not the config's - a local min-length check blamed the config
-    // file for a short --token flag.
+    // Only an empty token is rejected: validity is the API's job (401), and a local length check
+    // would blame the config file for a short --token flag.
     apiToken: z.string().min(1, "Required option 'api_token' is missing").optional(),
     basePath: z.string().default('.'),
     baseUrl: z
@@ -83,8 +81,8 @@ export const ConfigSchema = z
       })
       .optional(),
     // Optional: commands like `project list`, `language list`, `browse`, `context status` need only
-    // credentials (Java used a fileless ProjectProperties). Defaults to [] so file-command consumers
-    // and the superRefine below always see an array.
+    // credentials. Defaults to [] so file-command consumers and the superRefine below always see an
+    // array.
     files: z
       .array(
         z
@@ -103,7 +101,6 @@ export const ConfigSchema = z
                 error: 'translation parameter cannot be empty',
                 abort: true,
               })
-              // Java's PropertiesBuilder.hasRelativePaths rejects both forms, not just '../'.
               .refine((arg) => !arg.includes('../') && !arg.includes('/./'), {
                 error: "The 'translation' parameter can't contain any relative paths '../' or './'",
                 abort: true,
@@ -112,7 +109,7 @@ export const ConfigSchema = z
             context: z.string().optional(),
             scheme: z.union([z.string(), z.record(z.string(), z.number())]).optional(),
             multilingual: coercedBoolean.optional(),
-            // Parsed for Java config parity but inert: Java reads `multilingual` only.
+            // Accepted but inert: only `multilingual` marks a file multilingual.
             multilingual_spreadsheet: coercedBoolean.optional(),
             update_option: z
               .enum(Object.keys(UPDATE_OPTION_MAP) as [keyof typeof UPDATE_OPTION_MAP])
@@ -135,8 +132,7 @@ export const ConfigSchema = z
             export_only_approved: coercedBoolean.optional(),
             export_strings_that_passed_workflow: coercedBoolean.optional(),
           })
-          // Java normalizes the file section once, at config load
-          // (FileBean.populateWithDefaultValues); every consumer then reads settled values.
+          // Normalized once, at config load; every consumer then reads settled values.
           .transform((file) => {
             const translation = collapseSeparators(file.translation);
             const isMultilingual = isMultilingualFile(file);
@@ -145,11 +141,11 @@ export const ConfigSchema = z
             const normalized = {
               ...file,
               // A leading slash is never load-bearing for source/ignore/dest: every consumer strips
-              // or ignores it, so Java only collapses separator runs and leaves it as written.
+              // or ignores it, so only separator runs collapse and it stays as written.
               source: collapseSeparators(file.source),
               // `translation` becomes the uploaded exportPattern, where the slash *is* load-bearing:
               // the API rejects an exportPattern starting with '/' unless it carries a language
-              // placeholder, which is exactly the multilingual/scheme case Java strips it for.
+              // placeholder, which is exactly the multilingual/scheme case it is stripped for.
               translation:
                 isMultilingual && !hasLanguagePlaceholder
                   ? stripLeadingSlashes(translation)
@@ -181,9 +177,8 @@ export const ConfigSchema = z
         });
       }
 
-      // Java rejects this at config load (FileBean.checkProperties via
-      // PropertiesBuilder.checkForDoubleAsterisks), so it is a validation error (exit 2) rather
-      // than a CliError thrown later from replaceDoubleAsterisk while resolving a path.
+      // Rejected at config load, so it is a validation error (exit 2) rather than a CliError thrown
+      // later from replaceDoubleAsterisk while resolving a path.
       if (file.translation.includes('**') && !file.source.includes('**')) {
         ctx.addIssue({
           code: 'custom',
@@ -192,8 +187,8 @@ export const ConfigSchema = z
         });
       }
 
-      // Java FileBean.checkDest: when `source` matches more than one file, `dest` must vary per file
-      // — otherwise every match collapses onto the same project path.
+      // When `source` matches more than one file, `dest` must vary per file — otherwise every match
+      // collapses onto the same project path.
       if (
         file.dest &&
         (filePatterns.some((pattern) => file.source.includes(pattern)) || containsPattern(file.source)) &&
@@ -207,7 +202,6 @@ export const ConfigSchema = z
         });
       }
 
-      // Mirrors Java FileBean.checkProperties.
       if (!isMultilingualFile(file) && !languagePatterns.some((pattern) => file.translation.includes(pattern))) {
         ctx.addIssue({
           code: 'custom',
@@ -226,22 +220,20 @@ export const ConfigSchema = z
     });
   });
 
-// Mirrors Java's BaseProperties: credentials and file rules, no project context required.
+// Credentials and file rules, no project context required.
 export type Config = z.infer<typeof ConfigSchema>;
 
-// Mirrors Java's ProjectProperties: a Config whose project_id has been validated. Only the
-// project-scoped services ask for this; everything else is happy with a plain Config.
+// A Config whose project_id has been validated. Only the project-scoped services ask for this;
+// everything else is happy with a plain Config.
 export type ProjectConfig = Config & { projectId: number };
 
-// Project-scoped commands (Java ProjectProperties.checkProperties -> error.config.missed_project_id).
 export function assertProjectConfigured(config: Config): asserts config is ProjectConfig {
   if (config.projectId === undefined) {
     throw new InvalidConfigurationError("Required option 'project_id' is missing");
   }
 }
 
-// File commands (upload/download/config lint) call this to restore Java's parity error, which the
-// optional `files` section drops (PropertiesWithFiles.checkProperties -> empty_or_missed_section_files).
+// File commands (upload/download/config lint) call this, since the schema lets `files` be empty.
 export function assertFilesConfigured(config: Config): void {
   if (config.files.length === 0) {
     throw new InvalidConfigurationError("Required section 'files' is missing (or empty) in the configuration file");

--- a/src-next/lib/config/SourceFileLoader.ts
+++ b/src-next/lib/config/SourceFileLoader.ts
@@ -68,9 +68,8 @@ export default class SourceFileLoader {
 
   /**
    * Expands `ignore` patterns containing file placeholders into one literal pattern per scanned
-   * source file, mirroring the sources flatMap in Java's PlaceholderUtil.format: %file_name%,
-   * %file_extension%, %original_file_name% and %original_path% resolve from each source file's
-   * path. Patterns without a file placeholder pass through unchanged.
+   * source file: %file_name%, %file_extension%, %original_file_name% and %original_path% resolve
+   * from each source file's path. Patterns without a file placeholder pass through unchanged.
    */
   private expandFilePlaceholders(patterns: string[], files: string[]): string[] {
     const expanded = new Set<string>();
@@ -97,9 +96,8 @@ export default class SourceFileLoader {
   }
 
   /**
-   * Builds glob matchers for ignore patterns, mirroring Java's FileHelper.filterOutIgnoredFiles:
-   * directory patterns expand to match everything underneath, and `**`-prefixed patterns also
-   * match at the top level.
+   * Builds glob matchers for ignore patterns: directory patterns expand to match everything
+   * underneath, and `**`-prefixed patterns also match at the top level.
    */
   private buildIgnoreMatchers(ignore: string[]): Glob[] {
     if (ignore.length === 0) {

--- a/src-next/lib/config/errors/InvalidConfigurationError.ts
+++ b/src-next/lib/config/errors/InvalidConfigurationError.ts
@@ -1,9 +1,8 @@
 import ConfigurationError from './ConfigurationError.ts';
 
 export default class InvalidConfigurationError extends ConfigurationError {
-  // Java throws ValidationException (exit 2) for an invalid config. Hardcoded rather than
-  // imported from cli/errors ExitCode to keep lib/ free of a cli/ dependency; cli.ts
-  // getExitCode duck-types this `exitCode` property.
+  // Exit 2, the validation code. Hardcoded rather than imported from cli/errors ExitCode to keep
+  // lib/ free of a cli/ dependency; cli.ts getExitCode duck-types this `exitCode` property.
   readonly exitCode = 2;
 
   constructor(message: string = 'Invalid Configuration', options?: ErrorOptions) {

--- a/src-next/lib/config/projectFileMatch.ts
+++ b/src-next/lib/config/projectFileMatch.ts
@@ -2,11 +2,10 @@ import { replaceDoubleAsterisk } from '../utils/doubleAsterisk.ts';
 import { stripLeadingSlashes, toPosixPath } from '../utils/path.ts';
 
 /**
- * Translates a single source/translation glob pattern (or path segment) into a regex source string,
- * mirroring Java's PlaceholderUtil.formatSourcePatternForRegex: `**` matches across separators,
- * `*` matches within a segment, `?` matches a single non-separator character, and the file
- * placeholders collapse to wildcards. Language placeholders are left literal so they match the
- * literal placeholder text present on both sides.
+ * Translates a single source/translation glob pattern (or path segment) into a regex source string:
+ * `**` matches across separators, `*` matches within a segment, `?` matches a single non-separator
+ * character, and the file placeholders collapse to wildcards. Language placeholders are left literal
+ * so they match the literal placeholder text present on both sides.
  */
 export function globToRegex(pattern: string): string {
   let result = '';
@@ -30,12 +29,10 @@ export function globToRegex(pattern: string): string {
       continue;
     }
 
-    // Glob character sets ('[12]', '[a-z]', '[!0-9]') become regex classes. Java leaves brackets
-    // untouched (formatSourcePatternForRegex escapes only '.', '(' and ')'), and Bun's Glob — which
-    // scans the local sources — supports sets too, so escaping them here made server-side matching
-    // disagree with the local scan. '!' is translated to '^' to follow glob negation, as Bun does.
-    // An unterminated '[', or one whose ']' sits in another path segment, is a literal bracket in a
-    // file name and falls through to the escape branch below.
+    // Glob character sets ('[12]', '[a-z]', '[!0-9]') become regex classes, so server-side matching
+    // agrees with Bun's Glob, which scans the local sources. '!' is translated to '^' to follow glob
+    // negation, as Bun does. An unterminated '[', or one whose ']' sits in another path segment, is a
+    // literal bracket in a file name and falls through to the escape branch below.
     if (char === '[') {
       const end = pattern.indexOf(']', i + 2);
       const set = end === -1 ? undefined : pattern.slice(i + 1, end);
@@ -59,10 +56,10 @@ export function globToRegex(pattern: string): string {
 
   return (
     result
-      // Java makes a `**/` segment optional (PlaceholderUtil:308), so `/src/**/*.json` matches
-      // `src/app.json` as well as `src/main/app.json` — which is also what Bun's Glob does when
-      // scanning local sources. Applied before the placeholder substitutions, as in Java, so that
-      // `%original_path%/` (which only becomes `.+/` below) stays mandatory.
+      // A `**/` segment is optional, so `/src/**/*.json` matches `src/app.json` as well as
+      // `src/main/app.json`, as Bun's Glob does when scanning local sources. Applied before the
+      // placeholder substitutions so that `%original_path%/` (which only becomes `.+/` below) stays
+      // mandatory.
       .replaceAll('.+/', '(.+/)?')
       .replaceAll('%file_extension%', '[^/]+')
       .replaceAll('%file_name%', '[^/]+')
@@ -72,8 +69,7 @@ export function globToRegex(pattern: string): string {
 }
 
 /**
- * Decides whether a project file path matches a config group's source pattern, mirroring Java's
- * SourcesUtils.filterProjectFiles.
+ * Decides whether a project file path matches a config group's source pattern.
  *
  * - `preserveHierarchy` true: the whole pattern must match the whole path.
  * - `preserveHierarchy` false: only the trailing path segments need to match the pattern segments
@@ -103,8 +99,7 @@ export function matchesSourcePattern(filePath: string, sourcePattern: string, pr
 
 /**
  * Decides whether a project file's export pattern is compatible with a config group's translation
- * pattern, mirroring Java's ObsoleteSourcesUtils.checkExportPattern. When the project file has no
- * export pattern the check passes (nothing to contradict).
+ * pattern. When the project file has no export pattern the check passes (nothing to contradict).
  */
 export function matchesExportPattern(
   fileExportPattern: string | undefined,
@@ -118,9 +113,6 @@ export function matchesExportPattern(
   return matchesSourcePattern(fileExportPattern, translationPattern, preserveHierarchy);
 }
 
-/**
- * Mirrors Java SourcesUtils.containsPattern: whether a pattern contains glob metacharacters.
- */
 export function containsPattern(pattern: string): boolean {
   return (
     pattern.includes('**') ||
@@ -132,16 +124,16 @@ export function containsPattern(pattern: string): boolean {
 }
 
 /**
- * Replicates DownloadSourcesAction's manager-access pre-filter for one project file: decides whether
- * the file's server export pattern is compatible with the config group, so that with manager access
- * only files whose translations belong to the group are downloaded. Returns true to KEEP the file.
+ * The manager-access pre-filter for one project file: decides whether the file's server export
+ * pattern is compatible with the config group, so that with manager access only files whose
+ * translations belong to the group are downloaded. Returns true to KEEP the file.
  *
  * - `preserveHierarchy` false: the group `translation` (with each `/**` made optional) must partially
- *   match the export pattern (Java's `Pattern.asPredicate`).
+ *   match the export pattern (an unanchored regex test).
  * - `preserveHierarchy` true: when `dest` is set the file path must match the `dest` glob; otherwise
  *   the file's export pattern (when present) must be a suffix of the group `translation` after `**` is
- *   expanded from the project file path. A matched file is then additionally gated by Java's
- *   `sourceName == fileName || containsPattern(sourceName) || searchPattern.contains(path)` condition.
+ *   expanded from the project file path. A matched file must then also share the source's file name,
+ *   have a glob in the source's file name, or appear in the search pattern.
  */
 export function matchesManagerSourceFile(
   fileBean: { source: string; translation: string; dest?: string },
@@ -157,7 +149,7 @@ export function matchesManagerSourceFile(
       return true;
     }
 
-    // `/**` -> optional `(/.+)?`; placeholders stay literal. Partial match like Java asPredicate.
+    // `/**` -> optional `(/.+)?`; placeholders stay literal.
     const prepared = fileBean.translation.replace(/[\\/]\*\*/g, '(/.+)?').replace(/\\/g, '\\\\');
     return new RegExp(prepared).test(normalizedExport);
   }
@@ -168,8 +160,6 @@ export function matchesManagerSourceFile(
     const destPattern = stripLeadingSlashes(normalizePath(fileBean.dest));
     matchesFileBean = new RegExp(`^${globToRegex(destPattern)}$`).test(stripLeadingSlashes(normalizePath(filePath)));
   } else {
-    // Expand `**` from the project file path, then require the file's export pattern to be a suffix of
-    // the resulting translation pattern (mirrors Java DownloadSourcesAction's manager-access filter).
     const translationPattern = replaceDoubleAsterisk(fileBean.source, fileBean.translation, filePath);
     matchesFileBean = normalizedExport === undefined || translationPattern.endsWith(normalizedExport);
   }
@@ -193,9 +183,9 @@ function baseName(value: string): string {
 
 /**
  * Substitutes a project file's actual path segments into a source pattern's wildcard segments,
- * aligning from the right, mirroring Java's SourcesUtils.replaceUnaryAsterisk. A pattern segment is
- * replaced by the corresponding file segment only when the pattern segment is not `**` and the file
- * segment matches it. Used to derive `download sources` destinations from the source pattern.
+ * aligning from the right. A pattern segment is replaced by the corresponding file segment only when
+ * the pattern segment is not `**` and the file segment matches it. Used to derive `download sources`
+ * destinations from the source pattern.
  */
 export function replaceUnaryAsterisk(sourcePattern: string, projectFile: string): string {
   const parts = sourcePattern.split(/[\\/]+/);

--- a/src-next/lib/config/translationPathResolver.ts
+++ b/src-next/lib/config/translationPathResolver.ts
@@ -18,10 +18,9 @@ export interface ResolveOptions {
   /**
    * The group's `dest`, which moves file-dependent placeholders to the server location.
    *
-   * Only meaningful together with `serverOnly`. Java resolves the archive key
-   * (`translationProject2`) from `prepareDest(dest, file)` but always resolves the *local* path
-   * (`translationFile2`) from the source path, so passing `dest` without `serverOnly` would give a
-   * local path the server's placeholder values.
+   * Only meaningful together with `serverOnly`: the archive key is resolved from
+   * `prepareDest(dest, file)`, but the *local* path always from the source path, so passing `dest`
+   * without `serverOnly` would give a local path the server's placeholder values.
    */
   dest?: string;
   /** When false and `serverOnly` is set, `%original_path%` is dropped from the archive key. */
@@ -31,9 +30,8 @@ export interface ResolveOptions {
 /**
  * Resolves a translation path for one source file against the file group it belongs to.
  *
- * The group is a parameter, not something derived here. Deriving it — by finding the first group
- * whose `source` glob matches — silently used the wrong group's `translation` for a file that
- * several groups match, and ignored each group's `ignore` while doing it.
+ * The group is a parameter, not something derived here: several groups can match a file by their
+ * `source` glob, and each brings its own `translation` and `ignore`.
  */
 export function resolveTranslationPath(
   fileConfig: FileConfig,
@@ -44,14 +42,10 @@ export function resolveTranslationPath(
 ): string {
   const serverOnly = options?.serverOnly ?? false;
 
-  // File-dependent placeholders are normally resolved from the source path. For the server
-  // export path of a `dest`-configured group they are resolved from the dest location instead
-  // (mirrors Java's DownloadAction.doTranslationMapping).
-  // Java's dest branch throws the translation-derived pattern away and rebuilds the archive key from
-  // `dest` alone, resolved against the dest-prepared path — placeholders *and* `**` expansion, via
-  // the same replaceFileDependentPlaceholders the upload side uses. Because the translation-derived
-  // pattern is discarded, the `preserve_hierarchy` stripping below never applies here either
-  // (DownloadAction.doTranslationMapping).
+  // A `dest`-configured group resolves file-dependent placeholders from the dest location rather
+  // than the source path. With no language placeholder in `translation`, the archive key is `dest`
+  // alone — placeholders *and* `**` expansion, via the same replaceFileDependentPlaceholders the
+  // upload side uses — so the `preserve_hierarchy` stripping below never applies to it.
   if (options?.dest && !containsLanguagePlaceholder(fileConfig.translation)) {
     return replaceFileDependentPlaceholders(options.dest, prepareDest(options.dest, sourcePath));
   }
@@ -67,8 +61,7 @@ export function resolveTranslationPath(
     pattern = pattern.replaceAll(originalPath, '');
   }
 
-  // Substitute the `**`-matched subpath into the (translation-derived) pattern before resolving
-  // placeholders, mirroring Java's TranslationsUtils.replaceDoubleAsterisk.
+  // Substitute the `**`-matched subpath into the pattern before resolving placeholders.
   pattern = replaceDoubleAsterisk(fileConfig.source, pattern, sourcePath);
 
   const translationPath = collapseSeparators(

--- a/src-next/lib/config/yamlLoader.ts
+++ b/src-next/lib/config/yamlLoader.ts
@@ -1,19 +1,17 @@
-// js-yaml, not `yaml`: Java parses configs with SnakeYAML, which accepts input a spec-strict parser
-// rejects — notably a flow collection whose lines are not indented past its block key (`files: [{`
-// closing with `}` back at column 0), a style real Crowdin configs use. The `yaml` package raises
-// BAD_INDENT for that from the composer, ungated by any parse option (version/strict/schema), and
-// Bun.YAML rejects it too.
+// js-yaml, not `yaml`: real Crowdin configs use a style a spec-strict parser rejects — a flow
+// collection whose lines are not indented past its block key (`files: [{` closing with `}` back at
+// column 0). The `yaml` package raises BAD_INDENT for that from the composer, ungated by any parse
+// option (version/strict/schema), and Bun.YAML rejects it too.
 //
-// Held at js-yaml 4 on purpose: 5.0.0 started enforcing the same indentation rule ("deficient
-// indentation") and would reintroduce the failure. Verify against a config in that style before
-// taking the 5.x bump.
+// Held at js-yaml 4 on purpose: 5.x enforces the same indentation rule ("deficient indentation").
+// Verify against a config in that style before taking the 5.x bump.
 import { load as loadYaml } from 'js-yaml';
 import FileNotFoundError from '../common/errors/FileNotFoundError.ts';
 import InvalidConfigurationError from './errors/InvalidConfigurationError.ts';
 
 // Reads and YAML-parses a config file to a raw record, without validation or env resolution.
 // The full resolution pipeline (mapping, env, all sources, validation) lives in cli/config.ts,
-// so validation happens once, after everything is merged (mirrors Java build()).
+// so validation happens once, after everything is merged.
 export async function loadRawFromFile(filePath: string): Promise<Record<string, unknown>> {
   if (!(await Bun.file(filePath).exists())) {
     throw new FileNotFoundError(`File '${filePath}' does not exist`);
@@ -28,8 +26,7 @@ export function parseYaml(string: string): Record<string, unknown> {
   try {
     config = loadYaml(string);
   } catch (error) {
-    // Java surfaces a broken config file as a validation failure (exit 2); mirror that
-    // instead of leaking the raw YAML parser error.
+    // A validation failure (exit 2) rather than the raw YAML parser error.
     throw new InvalidConfigurationError('Configuration file has invalid YAML syntax.', { cause: error });
   }
 
@@ -43,7 +40,7 @@ export function parseYaml(string: string): Record<string, unknown> {
 // Maps a raw YAML config record's literal keys to ConfigSchema input (snake_case -> camelCase).
 // Env-variable resolution is a separate pipeline layer (see cli/config.ts), not here.
 export function mapConfig(raw: Record<string, unknown>): Record<string, unknown> {
-  // Java nests ignore_hidden_files under a `settings:` map (SettingsBean).
+  // ignore_hidden_files lives under a `settings:` map.
   const settings = (raw.settings ?? {}) as Record<string, unknown>;
 
   return {

--- a/src-next/lib/download/languages.ts
+++ b/src-next/lib/download/languages.ts
@@ -11,16 +11,15 @@ export interface ResolvedDownloadLanguages {
   languages: LanguagesModel.Language[];
   /**
    * Ids to pin as `targetLanguageIds` on the build request, or undefined to let the server build
-   * every language. Java only pins them when the set was actually narrowed.
+   * every language. Only pinned when the set was actually narrowed.
    */
   languageIds?: string[];
 }
 
 /**
- * Resolves which languages `download translations` should build and map, mirroring Java's
- * DownloadAction. `projectLanguages` is Java's `getProjectLanguages(true)` — the target languages
- * plus the in-context pseudo language when the project has one — and every id given on the command
- * line or in `export_languages` has to appear in it.
+ * Resolves which languages `download translations` should build and map. `projectLanguages` is the
+ * target languages plus the in-context pseudo language when the project has one, and every id given
+ * on the command line or in `export_languages` has to appear in it.
  */
 export function resolveDownloadLanguages(
   projectLanguages: LanguagesModel.Language[],
@@ -66,7 +65,7 @@ export function resolveDownloadLanguages(
 
   return {
     languages,
-    // Only pinned when export_languages or excludes actually narrowed the set (Java parity).
+    // Only pinned when export_languages or excludes actually narrowed the set.
     ...(configured.length > 0 || excluded.length > 0 ? { languageIds: languages.map((l) => l.id) } : {}),
   };
 }

--- a/src-next/lib/download/projectTranslations.ts
+++ b/src-next/lib/download/projectTranslations.ts
@@ -13,9 +13,9 @@ interface ProjectFileInfo {
 }
 
 /**
- * Maps every project source file to the list of its server export (translation) paths, mirroring
- * Java's ProjectFilesUtils.buildAllProjectTranslations. Used to classify omitted archive entries
- * into those that belong to a known project source and those without a source.
+ * Maps every project source file to the list of its server export (translation) paths. Used to
+ * classify omitted archive entries into those that belong to a known project source and those
+ * without a source.
  *
  * Keys and values are posix paths relative to the project root (no leading slash).
  */
@@ -69,7 +69,7 @@ export interface OmittedFiles {
 
 /**
  * Splits omitted archive entries into those that correspond to a known project source (grouped by
- * source) and those without a source, mirroring Java's DownloadAction.sortOmittedFiles.
+ * source) and those without a source.
  */
 export function sortOmittedFiles(omittedFiles: string[], allProjectTranslations: Map<string, string[]>): OmittedFiles {
   const withSources = new Map<string, string[]>();

--- a/src-next/lib/download/translationMapping.ts
+++ b/src-next/lib/download/translationMapping.ts
@@ -19,20 +19,19 @@ export interface TranslationMappingOptions {
   files?: Config['files'];
   /**
    * Server-side excluded target languages per source path (basePath-relative posix key, no leading
-   * slash). A language listed for a source is skipped for that source, mirroring Java's
-   * DryrunTranslations.containsExcludedLanguage. Only the dry-run listing applies this (Java's real
-   * DownloadAction does not filter excluded languages).
+   * slash). A language listed for a source is skipped for that source. Only the dry-run listing
+   * applies this; the real download does not filter excluded languages.
    */
   excludedTargetLanguagesByPath?: Map<string, string[]>;
 }
 
 /**
- * Builds the archive-to-local path mapping for `download translations`, mirroring Java's
- * DownloadAction.getFiles -> doTranslationMapping. For each config group, over every source file
- * and resolved language, it pairs the server export path (the path inside the downloaded archive)
- * with the desired local destination (which applies per-file `languages_mapping` and
- * `translation_replace`). With `useServerSources`, server-only project files matching a group are
- * added so files present on the server but absent locally are still downloaded.
+ * Builds the archive-to-local path mapping for `download translations`. For each config group, over
+ * every source file and resolved language, it pairs the server export path (the path inside the
+ * downloaded archive) with the desired local destination (which applies per-file
+ * `languages_mapping` and `translation_replace`). With `useServerSources`, server-only project files
+ * matching a group are added so files present on the server but absent locally are still
+ * downloaded.
  */
 export function buildTranslationMapping(
   config: Config,
@@ -55,7 +54,7 @@ export function buildTranslationMapping(
 
     if (options?.useServerSources) {
       const localSet = new Set(localSourcePaths.map((p) => toPosixPath(p)));
-      // Java filters by `dest` (when set) instead of `source` for server files.
+      // Server files sit at their `dest` path, so match by that when set.
       const searchPattern = patterns.dest ?? patterns.source;
       const ignore = patterns.ignore ?? [];
 
@@ -79,7 +78,6 @@ export function buildTranslationMapping(
       );
 
       for (const language of languages) {
-        // Skip languages the server source file excludes (parity with DryrunTranslations).
         if (excludedLanguages?.includes(language.id)) {
           continue;
         }

--- a/src-next/lib/export/languagePlaceholders.ts
+++ b/src-next/lib/export/languagePlaceholders.ts
@@ -13,7 +13,7 @@ import {
 } from './patterns.ts';
 
 // Maps a language placeholder to the language-mapping key(s) used to look up an override.
-// Order matters: the first key that has an override wins (mirrors Java's PlaceholderUtil).
+// Order matters: the first key that has an override wins.
 const PLACEHOLDER_MAPPING_KEYS: Record<string, string[]> = {
   [languagePattern]: ['language', 'name'],
   [locale]: ['locale'],
@@ -28,7 +28,7 @@ const PLACEHOLDER_MAPPING_KEYS: Record<string, string[]> = {
 
 /**
  * Resolves a language-mapping override for a placeholder, with the per-file config mapping
- * taking precedence over the server mapping (mirrors Java's LanguageMapping.populate).
+ * taking precedence over the server mapping.
  *
  * Config mapping shape: { placeholder: { langId: value } }
  * Server mapping shape: { langId: { placeholder: value } }
@@ -88,8 +88,7 @@ export function languagePlaceholderValue(
     case locale:
       return language.locale;
     case localeWithUnderscore:
-      // Every separator, not just the first: Java's String.replace is global, and locales such as
-      // `po-CR-UA` carry two.
+      // Every separator, not just the first: locales such as `po-CR-UA` carry two.
       return language.locale.replaceAll('-', '_');
     case threeLettersCode:
       return language.threeLettersCode;
@@ -129,8 +128,7 @@ export function containsLanguagePlaceholder(pattern: string): boolean {
 
 /**
  * Expands `ignore` patterns containing language placeholders into one literal pattern per project
- * language (deduped), mirroring Java's PlaceholderUtil.format(sources, ignorePatterns,
- * languageMapping). Patterns without a language placeholder pass through unchanged.
+ * language (deduped). Patterns without a language placeholder pass through unchanged.
  */
 export function expandIgnorePatterns(
   patterns: string[],

--- a/src-next/lib/export/patterns.ts
+++ b/src-next/lib/export/patterns.ts
@@ -44,8 +44,8 @@ const allPlaceholders = [
 
 export default allPlaceholders;
 
-// Mirrors Java's PlaceholderUtil.validStringPattern: any path segment that is wrapped in % must be
-// a known placeholder. Segments that aren't fully %-wrapped (literals, globs) are left untouched.
+// Any path segment that is wrapped in % must be a known placeholder. Segments that aren't fully
+// %-wrapped (literals, globs) are left untouched.
 export function validTranslationPattern(pattern: string): boolean {
   for (const segment of pattern.split('/')) {
     if (segment.startsWith('%') && segment.endsWith('%') && !allPlaceholders.includes(segment)) {

--- a/src-next/lib/identityFiles.ts
+++ b/src-next/lib/identityFiles.ts
@@ -3,9 +3,8 @@ import path from 'node:path';
 
 const ALT_IDENTITY_FILE = '.crowdin.yaml';
 
-// Default identity files in the home directory, matching Java's BaseCli.DEFAULT_IDENTITY_FILES.
-// Used as the fallback credentials source when --identity is not passed, and as the target that
-// `crowdin init` writes the shared API token to.
+// Default identity files in the home directory. Used as the fallback credentials source when
+// --identity is not passed, and as the target that `crowdin init` writes the shared API token to.
 export const DEFAULT_IDENTITY_FILE = '.crowdin.yml';
 export const IDENTITY_FILE_NAMES = [DEFAULT_IDENTITY_FILE, ALT_IDENTITY_FILE];
 

--- a/src-next/lib/organization/credentials.ts
+++ b/src-next/lib/organization/credentials.ts
@@ -3,8 +3,8 @@ import type { Credentials } from '@crowdin/crowdin-api-client';
 const CROWDIN_API_DOMAIN = 'api.crowdin.com';
 
 /**
- * Extracts the Crowdin Enterprise organization name from a base URL, mirroring Java's
- * PropertiesBeanUtils.getOrganization. Returns undefined for the standard crowdin.com host.
+ * Extracts the Crowdin Enterprise organization name from a base URL. Returns undefined for the
+ * standard crowdin.com host.
  */
 export function getOrganization(baseUrl: string): string | undefined {
   const organization = baseUrl
@@ -18,7 +18,7 @@ export function getOrganization(baseUrl: string): string | undefined {
   return organization.length === 0 ? undefined : organization;
 }
 
-/** Mirrors Java's PropertiesBeanUtils.isUrlForTesting: internal Crowdin dev/test hosts. */
+/** Internal Crowdin dev/test hosts. */
 export function isUrlForTesting(baseUrl: string): boolean {
   return (
     /^https:\/\/[^.]+\.crowdin\.dev(\/api\/v2)?$/.test(baseUrl) ||
@@ -40,7 +40,7 @@ function getApiDomain(baseUrl: string, organization: string | undefined): string
 }
 
 /**
- * Builds api-client credentials from a token + config base URL, mirroring Java's Clients.prepareClient.
+ * Builds api-client credentials from a token + config base URL.
  * For testing hosts the raw base URL is passed through (client uses it verbatim, so ensure /api/v2);
  * otherwise only the organization is passed and the client derives the standard URL.
  */

--- a/src-next/lib/upload/fileLookup.ts
+++ b/src-next/lib/upload/fileLookup.ts
@@ -5,11 +5,10 @@ export interface FileLookupResult {
 }
 
 /**
- * Resolves a project file path against the project's existing files, mirroring Java's
- * ProjectFilesUtils.fileLookup: an exact path wins; otherwise a path matching when ignoring the
- * final extension is a soft match; otherwise a path matching when one side keeps an extra extension
- * is used as a fallback soft match. Soft matches are reported with `exact: false` so callers can
- * rename the project file to the local source name.
+ * Resolves a project file path against the project's existing files: an exact path wins; otherwise
+ * a path matching when ignoring the final extension is a soft match; otherwise a path matching when
+ * one side keeps an extra extension is used as a fallback soft match. Soft matches are reported
+ * with `exact: false` so callers can rename the project file to the local source name.
  */
 export function fileLookup(
   filePath: string,

--- a/src-next/lib/upload/fileOptions.ts
+++ b/src-next/lib/upload/fileOptions.ts
@@ -15,8 +15,7 @@ export function buildExportOptions(
   exportPattern?: string,
 ): SourceFilesModel.ExportOptions {
   const extension = path.extname(localFilePath).toLowerCase();
-  // Expand `**` in the export pattern from the matched source subpath (mirrors Java buildExportOptions).
-  // Java collapses separator runs in the export pattern before sending it (UploadSourcesAction:539).
+  // Expand `**` in the export pattern from the matched source subpath, and collapse separator runs.
   const resolvedExportPattern =
     exportPattern !== undefined
       ? collapseSeparators(replaceDoubleAsterisk(fileConfig.source, exportPattern, toPosixPath(localFilePath)))
@@ -113,9 +112,9 @@ function omitUndefined<T extends Record<string, unknown>>(value: T): T | undefin
 }
 
 /**
- * Maps a local source path to its path inside the Crowdin project, mirroring Java's
- * UploadSourcesAction: an explicit `dest` wins, otherwise the common path is stripped unless
- * `preserve_hierarchy` is enabled (in which case `commonPath` is empty).
+ * Maps a local source path to its path inside the Crowdin project: an explicit `dest` wins,
+ * otherwise the common path is stripped unless `preserve_hierarchy` is enabled (in which case
+ * `commonPath` is empty).
  */
 export function resolveProjectPath(localFilePath: string, patterns: { dest?: string }, commonPath: string): string {
   if (patterns.dest) {
@@ -135,11 +134,10 @@ export function resolveContextPath(pattern: string, localFilePath: string): stri
 
 /**
  * Substitutes the file-dependent placeholders (`%file_name%`, `%original_path%`, …) in a `dest` or
- * `context` pattern, mirroring Java's PlaceholderUtil.replaceFileDependentPlaceholders.
+ * `context` pattern.
  *
- * `localFilePath` is posix and relative to basePath — Java's `fileParent` is likewise
- * basePath-relative. The download archive key passes a server project path instead, matching Java's
- * `new File(prepareDest(dest, file))`.
+ * `localFilePath` is posix and relative to basePath. The download archive key passes a server
+ * project path instead.
  */
 export function replaceFileDependentPlaceholders(pattern: string, localFilePath: string): string {
   const parsed = path.posix.parse(localFilePath);
@@ -163,23 +161,20 @@ export function replaceFileDependentPlaceholders(pattern: string, localFilePath:
     resolved = expandDestDoubleAsterisk(resolved, localFilePath, parsed.dir);
   }
 
-  // Java ends the method by collapsing separator runs and dropping a leading one.
   return stripLeadingSlashes(collapseSeparators(resolved));
 }
 
 /**
- * Resolves the `dest` config option into a project file path, mirroring Java's
- * PropertiesBeanUtils.prepareDest: file-dependent placeholders are substituted from the local
- * source path and any leading separator is stripped.
+ * Resolves the `dest` config option into a project file path: file-dependent placeholders are
+ * substituted from the local source path and any leading separator is stripped.
  */
 export function prepareDest(dest: string, localFilePath: string): string {
-  // replaceFileDependentPlaceholders already drops the leading separator, as Java's does.
   return toPosixPath(replaceFileDependentPlaceholders(dest, localFilePath));
 }
 
 /**
- * Computes the common directory prefix of the given POSIX file paths (relative to basePath),
- * mirroring Java's SourcesUtils.getCommonPath. Returns a string ending in '/' or an empty string.
+ * Computes the common directory prefix of the given POSIX file paths (relative to basePath).
+ * Returns a string ending in '/' or an empty string.
  */
 export function getCommonPath(filePaths: string[]): string {
   if (filePaths.length === 0) {

--- a/src-next/lib/upload/obsoleteEntries.ts
+++ b/src-next/lib/upload/obsoleteEntries.ts
@@ -20,7 +20,7 @@ export async function deleteObsoleteProjectEntries(
   branchName?: string,
 ) {
   // Server paths carry the branch name; expectedProjectFilePaths (and the source patterns matched
-  // below) never do, so drop it before comparing. Java uses the branch-less path map here too.
+  // below) never do, so drop it before comparing.
   const stripBranch = (projectPath: string) => stripBranchPrefix(projectPath, branchName);
   // Retain every project file the upload would match — including soft (extension-insensitive)
   // matches — so a file that will be updated/renamed is never deleted as obsolete first.
@@ -37,9 +37,8 @@ export async function deleteObsoleteProjectEntries(
     }
   }
 
-  // Only delete files that fall under a configured `source` pattern (and aren't ignored). This
-  // scopes deletion to files this config manages, mirroring Java's ObsoleteSourcesUtils — files
-  // outside every source pattern are left untouched.
+  // Only delete files that fall under a configured `source` pattern (and aren't ignored): files
+  // outside every source pattern are not this config's to delete.
   const obsoleteFiles = projectFiles.filter(
     (projectFile) =>
       !retainedFileIds.has(projectFile.data.id) &&
@@ -53,8 +52,6 @@ export async function deleteObsoleteProjectEntries(
 
   for (const projectFile of obsoleteFiles) {
     const projectFilePath = stripBranch(projectFile.data.path);
-    // Java reports obsolete paths relative (Dryrun strips leading separators, and the
-    // sub-action's path map is built without one).
     const displayPath = stripLeadingSlashes(projectFilePath);
 
     if (dryRun) {
@@ -71,10 +68,9 @@ export async function deleteObsoleteProjectEntries(
       .map((projectFile) => stripBranch(projectFile.data.path)),
     ...expectedProjectFilePaths,
   ]);
-  // Java only ever considers directories that held a file it just deleted, plus their ancestors
-  // (ObsoleteSourcesUtils.findObsoleteProjectDirectories builds its candidates from
-  // obsoleteDeletedProjectFiles). Scanning every project directory instead would delete empty
-  // directories that no config references — ones a manager created in the Crowdin UI, say.
+  // Only directories that held a just-deleted file, plus their ancestors, are candidates. Scanning
+  // every project directory instead would delete empty directories that no config references — ones
+  // a manager created in the Crowdin UI, say.
   const obsoleteDirectoryCandidates = new Set<string>();
 
   for (const projectFile of obsoleteFiles) {
@@ -121,16 +117,13 @@ export async function deleteObsoleteProjectEntries(
 }
 
 /**
- * Whether a project file is covered by any configured group (and not ignored). Java runs this per
- * group (`DeleteObsoleteProjectFilesSubAction.act`), so `source` and `translation` stay paired: a
- * file only counts as managed when the same group both matches its path and accepts its stored
- * export pattern (`ObsoleteSourcesUtils.checkExportPattern`).
+ * Whether a project file is covered by any configured group (and not ignored). Checked per group,
+ * so `source` and `translation` stay paired: a file only counts as managed when the same group both
+ * matches its path and accepts its stored export pattern.
  *
- * Matching goes through `matchesSourcePattern`, the port of the same regex machinery Java uses here
- * (`ProjectFilesUtils.isProjectFilePathSatisfiesPatterns` builds exactly the anchored /
- * optional-leading-segment patterns that `formatSourcePatternForRegex` feeds). This used to run on
- * `cli/utils/pathMatcher`, which is for user-supplied CLI file filters and expands no placeholders,
- * so a `source` carrying `%original_file_name%` matched nothing here.
+ * Matching goes through `matchesSourcePattern`, not `cli/utils/pathMatcher`: that one is for
+ * user-supplied CLI file filters and expands no placeholders, so a `source` carrying
+ * `%original_file_name%` would match nothing.
  */
 function isManagedBySourcePatterns(
   projectPath: string,
@@ -144,7 +137,7 @@ function isManagedBySourcePatterns(
     }
 
     // A file whose translations land outside this group's `translation` belongs to another group;
-    // deleting it here would destroy translations Java keeps.
+    // deleting it here would destroy that group's translations.
     if (!matchesExportPattern(fileExportPattern, translation, preserveHierarchy)) {
       return false;
     }
@@ -153,7 +146,7 @@ function isManagedBySourcePatterns(
   });
 }
 
-/** Parent of a project path, or '' at the root (mirrors the walk in Utils.getParentDirectory). */
+/** Parent of a project path, or '' at the root. */
 function parentDirectory(projectPath: string): string {
   const lastSeparator = toProjectPath(projectPath).lastIndexOf('/');
 

--- a/src-next/lib/utils/doubleAsterisk.ts
+++ b/src-next/lib/utils/doubleAsterisk.ts
@@ -2,14 +2,12 @@ import CliError from '@/cli/errors/CliError.ts';
 import { collapseSeparators, stripLeadingSlashes, stripTrailingSlashes } from './path.ts';
 
 /*
- * Java expands `**` two different ways, and this file ports both. They are not interchangeable:
+ * `**` expands two different ways, and they are not interchangeable:
  *
- *   replaceDoubleAsterisk    (TranslationsUtils)  - for `translation`/export patterns. Matches the
- *                                                   file against the group's `source` glob, so its
- *                                                   result changes with that glob.
- *   expandDestDoubleAsterisk (PlaceholderUtil)    - for `dest`/`context`, which have no glob to
- *                                                   match against; works off the file's parent path
- *                                                   and the pattern's own prefix/postfix.
+ *   replaceDoubleAsterisk    - for `translation`/export patterns. Matches the file against the
+ *                              group's `source` glob, so its result changes with that glob.
+ *   expandDestDoubleAsterisk - for `dest`/`context`, which have no glob to match against; works off
+ *                              the file's parent path and the pattern's own prefix/postfix.
  *
  * Same pattern and file through both: `/out/**\/app.json` + `src/nested/deep/app.json` gives
  * `/out/nested/deep/app.json` for a `/src/**\/*.json` source, but `out/src/nested/deep/app.json`
@@ -17,13 +15,12 @@ import { collapseSeparators, stripLeadingSlashes, stripTrailingSlashes } from '.
  */
 
 /**
- * Substitutes the `**`-matched portion of a source file path into a translation pattern, mirroring
- * Java's TranslationsUtils.replaceDoubleAsterisk. The `source` pattern is split on `**`; each node is
- * trimmed from the file path so that what remains is the subpath the `**` actually matched, and that
- * subpath replaces `**` in the translation pattern. Operates on POSIX paths (use toPosixPath first).
+ * Substitutes the `**`-matched portion of a source file path into a translation pattern. The
+ * `source` pattern is split on `**`; each node is trimmed from the file path so that what remains is
+ * the subpath the `**` actually matched, and that subpath replaces `**` in the translation pattern.
+ * Operates on POSIX paths (use toPosixPath first).
  *
- * `sourceFile` must be relative to the base path (no leading separator), matching Java's
- * `StringUtils.removeStart(projectFile, basePath)`.
+ * `sourceFile` must be relative to the base path (no leading separator).
  */
 export function replaceDoubleAsterisk(sourcePattern: string, translationPattern: string, sourceFile: string): string {
   if (!translationPattern || !sourceFile) {
@@ -70,14 +67,13 @@ export function replaceDoubleAsterisk(sourcePattern: string, translationPattern:
     }
   }
 
-  // Replacer function, not a string: Java's String.replace(CharSequence, CharSequence) is literal,
-  // while a string replacement would interpret `$&`/`$'`/`$$` in path-derived text.
+  // Replacer function, not a string, so `$&`/`$'`/`$$` in path-derived text stay literal.
   return translationPattern.replaceAll('**', () => file).replace(/\/+/g, '/');
 }
 
 /**
- * Escapes the characters Java's Utils.regexPath escapes (`\ ( ) + [ ]`) for use in a regex, leaving
- * `* ? .` as regex metacharacters — matching Java's behavior where remaining glob chars act as regex.
+ * Escapes `\ ( ) + [ ]` for use in a regex, leaving `* ? .` as regex metacharacters so the remaining
+ * glob chars act as regex.
  */
 function regexPath(path: string): string {
   return path
@@ -90,8 +86,8 @@ function regexPath(path: string): string {
 }
 
 /**
- * Mirrors Apache Commons StringUtils.substring(str, start, end): negative indices count from the end,
- * the range is clamped, and an inverted range yields an empty string (instead of JS's arg-swapping).
+ * Negative indices count from the end, the range is clamped, and an inverted range yields an empty
+ * string (instead of JS's arg-swapping).
  */
 function apacheSubstring(str: string, start: number, end: number): string {
   let startIndex = start < 0 ? str.length + start : start;
@@ -119,9 +115,6 @@ function apacheSubstring(str: string, start: number, end: number): string {
 /**
  * Replaces `**` in a resolved `dest`/`context` pattern with the slice of the source file's parent
  * path that the wildcard stands for.
- *
- * This is a different algorithm from `replaceDoubleAsterisk` (a port of Java's TranslationsUtils),
- * which serves `translation` patterns and matches against the `source` glob instead.
  */
 export function expandDestDoubleAsterisk(pattern: string, localFilePath: string, fileParent: string): string {
   const prefixFormat = substringBefore(pattern, '**');
@@ -153,13 +146,10 @@ export function expandDestDoubleAsterisk(pattern: string, localFilePath: string,
     expanded = removeEnd(expanded, stripTrailingSlashes(postfix));
   }
 
-  // Java's String.replace(CharSequence, CharSequence) substitutes every occurrence, not just the
-  // first, and does so literally — hence a replacer function rather than a string, which would
-  // interpret `$&`/`$'`/`$$` in the path-derived replacement.
+  // Replacer function, not a string, so `$&`/`$'`/`$$` in path-derived text stay literal.
   return pattern.replaceAll('**', () => expanded);
 }
 
-// Apache commons-lang semantics, which the ported block above depends on.
 function substringBefore(value: string, separator: string): string {
   const index = value.indexOf(separator);
   return index === -1 ? value : value.slice(0, index);
@@ -191,7 +181,7 @@ function removeEnd(value: string, remove: string): string {
   return remove.length > 0 && value.endsWith(remove) ? value.slice(0, -remove.length) : value;
 }
 
-/** Java Utils.getParentDirectory: the parent with a trailing separator, or '/' when there is none. */
+/** The parent with a trailing separator, or '/' when there is none. */
 function parentDirectory(value: string): string {
   const trimmed = stripTrailingSlashes(value);
 

--- a/src-next/lib/utils/path.ts
+++ b/src-next/lib/utils/path.ts
@@ -26,9 +26,7 @@ export function toProjectPath(filePath: string): string {
  * (`/dev/sources/en.json` -> `/sources/en.json`).
  *
  * Local paths resolved from the config never carry the branch, so every comparison
- * between a server path and a config-derived path has to drop it first. Java instead
- * prefixes the local path (BranchUtils.getBranchPrefix); stripping is equivalent here
- * because the file list is already scoped to a single branch by `branchId`.
+ * between a server path and a config-derived path has to drop it first.
  */
 export function stripBranchPrefix(projectPath: string, branchName?: string): string {
   if (!branchName) {


### PR DESCRIPTION
## Summary

Many comments in `src-next` were written while porting from the Java CLI. They still read as porting notes rather than as documentation of the current code. This PR changes comments only and cleans up three kinds of problem:

- **Java-pointing comments** explained behaviour by referring to Java classes (`Mirrors Java PropertiesBuilders…`, `Java's DryrunSources…`). They now say what the code does and why. Where a behaviour is deliberately unusual, the comment gives the reason, not where it came from. For example, `--dryrun` stays one word because it's the spelling existing scripts use.
- **Timeline narratives** described what the code used to do (`They used to print to stdout…`, `without this the path was missing…`). They are removed, since history belongs in commit messages. The one issue link (`oven-sh/bun#40278`) is also removed; the explanation of why `downloadToFile` avoids `Bun.write` stays.
- **Obvious comments** that repeated the next line are deleted (`Check promise cache first`, `Java message.file.list`, `// 24 hr`, and a comment repeated twice in the same file).

Comments that carry intent, a non-obvious constraint or an edge case are kept, and some were shortened.

Two comments were factually wrong and are corrected:
- `cli/builder.ts` claimed to match picocli's `Unknown subcommand 'X'` message, but the code prints `unknown command`.
- `cli/errors/toCliError.ts` said ECONNREFUSED "always points at base_url", but the code treats it as a connection failure. Only ENOTFOUND points at `base_url`.

## Numbers

- 87 files changed, +421 / −624
- Comment lines: 1390 → 1187
- Java/picocli mentions in comments: 261 → 0
